### PR TITLE
Fix error for Qt built with -reduce-relocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,9 @@ if (TEXMACS_GUI MATCHES "Qt.*")
       ${Qt5Widgets_INCLUDE_DIRS}
       ${Qt5PrintSupport_INCLUDE_DIRS}
     )
+    if (Qt5_POSITION_INDEPENDENT_CODE)
+      set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+    endif (Qt5_POSITION_INDEPENDENT_CODE)
   endif (TEXMACS_GUI STREQUAL "Qt4")
 
   add_definitions (${QT_DEFINITIONS})


### PR DESCRIPTION
Hi, I've encountered a compilation error when `make`:
```
/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1135:4: error: #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (-fPIE is not enough)."
 #  error "You must build your code with position independent code if Qt was built with -reduce-relocations. "\
    ^~~~~
```
The qt version is 5.9.5, installed from `apt`. I'm not familiar with qt or cmake, and just duckduckgo the error message and found the solution discussed in [qt forum](forum.qt.io/topic/28359/qt5-compilation-catastrophic-error).

Below is the full error log:
```
[ 11%] Building CXX object src/CMakeFiles/texmacs_body.dir/Edit/Editor/edit_main.cpp.o
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qsharedpointer.h:43:0,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qpointer.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QPointer:1,
                 from /home/redbug312/下載/trunk/src/src/Plugins/Qt/qt_widget.hpp:17,
                 from /home/redbug312/下載/trunk/src/src/Plugins/Qt/qt_simple_widget.hpp:18,
                 from /home/redbug312/下載/trunk/src/src/Edit/editor.hpp:20,
                 from /home/redbug312/下載/trunk/src/src/Edit/Interface/edit_interface.hpp:14,
                 from /home/redbug312/下載/trunk/src/src/Edit/Editor/edit_main.hpp:14,
                 from /home/redbug312/下載/trunk/src/src/Edit/Editor/edit_main.cpp:12:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1135:4: error: #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (-fPIE is not enough)."
 #  error "You must build your code with position independent code if Qt was built with -reduce-relocations. "\
    ^~~~~
src/CMakeFiles/texmacs_body.dir/build.make:1694: recipe for target 'src/CMakeFiles/texmacs_body.dir/Edit/Editor/edit_main.cpp.o' failed
make[2]: *** [src/CMakeFiles/texmacs_body.dir/Edit/Editor/edit_main.cpp.o] Error 1
CMakeFiles/Makefile2:1023: recipe for target 'src/CMakeFiles/texmacs_body.dir/all' failed
make[1]: *** [src/CMakeFiles/texmacs_body.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
```