### PR TITLE
[SVN] Open HTTP hyperlinks with an external browser

### DIFF
--- a/TeXmacs/progs/link/link-navigate.scm
+++ b/TeXmacs/progs/link/link-navigate.scm
@@ -468,7 +468,11 @@
   (load-browse-buffer u))
 
 (define (http-root-handler u)
-  (load-browse-buffer u))
+  (let ((os-open (cond ((os-macos?) "open")
+                       ((os-mingw?) "start")
+                       (else "xdg-open"))))
+
+  (system (string-append os-open " " (url->system (url-expand u))))))
 
 (define (url-handlers u)
   (with root (or (and (url-rooted? u) (url-root u)) "default")


### PR DESCRIPTION
TeXmacs currently loads HTTP hyperlinks in a new buffer. It is preferable to open them in a web browser.