### PR TITLE
[SVN] Maxima may not return the list of available versions

### DIFF
--- a/plugins/maxima/bin/maxima_detect
+++ b/plugins/maxima/bin/maxima_detect
@@ -21,11 +21,16 @@ then
       maxima -d | grep -F 'maxima-htmldir=' |\
         sed -e 's/maxima-htmldir=/"/' -e 's|$|/maxima_toc.html"|'
     else
-      echo '('
-      maxima --list-avail |\
-        grep '^version [A-Za-z0-9\.][A-Za-z0-9\.]*, lisp [A-Za-z0-9][A-Za-z0-9]*$' |\
-        sed -e 's/^version \([A-Za-z0-9\.][A-Za-z0-9\.]*\), lisp \([A-Za-z0-9][A-Za-z0-9]*\)$/"\1 \2"/'
-      echo ')'
+      MAXIMA=$(maxima --list-avail 2>/dev/null |\
+      grep '^version [A-Za-z0-9\.][A-Za-z0-9\.]*, lisp [A-Za-z0-9][A-Za-z0-9]*$' |\
+      sed -e 's/^version \([A-Za-z0-9\.][A-Za-z0-9\.]*\), lisp \([A-Za-z0-9][A-Za-z0-9]*\)$/"\1 \2"/')
+      if [ -z "$MAXIMA" ]
+      then
+          # maxima did not return the list of available versions
+          echo '#f'
+      else
+          echo '('$MAXIMA')'
+      fi
     fi
   fi
 else


### PR DESCRIPTION
Currently `maxima_detect` checks whether it can find Maxima, and if it does, it assumes that Maxima runs. But Maxima may not work because it cannot find SBCL, etc.

Now `maxima_detect` verifies whether Maxima returned the list of available versions or not.