### PR TITLE
[SVN] Guarantee that the master file is loaded

### DIFF
--- a/src/Texmacs/Data/new_project.cpp
+++ b/src/Texmacs/Data/new_project.cpp
@@ -62,8 +62,11 @@ project_attached () {
 
 url
 project_get () {
-  tm_buffer buf= concrete_buffer (get_current_buffer ());
+  url name = get_current_buffer();
+  tm_buffer buf= concrete_buffer (name);
   if (is_implicit_project (buf)) return buf->buf->name;
   if (buf->data->project == "") return url_none ();
+  url prj_name = head(name) * as_string(buf->data->project);
+  buf->prj = concrete_buffer_insist(prj_name);
   return buf->prj->buf->name;
 }


### PR DESCRIPTION
When `file.tm`, which is part of a project, is opened both `file.tm` and the main project file are loaded in two buffers. Each `tm_buffer` has a `prj` field. The `prj` field of the buffer showing `file.tm` gets assigned the buffer showing the main project file. When this buffer is killed, the `prj` field points to memory that is no longer available thus producing a segmentation fault.

This patch makes sure that when `project_get` is called the main project file is loaded in a buffer and therefore it can retrieve the name of that buffer.