### PR TITLE
[SVN] Set a default bib style so that BibTeX does not fail

### DIFF
--- a/src/Edit/Process/edit_process.cpp
+++ b/src/Edit/Process/edit_process.cpp
@@ -107,6 +107,7 @@ void
 edit_process_rep::generate_bibliography (
   string bib, string style, string fname)
 {
+  if (N(style) == 0) style = "tm-plain";
   system_wait ("Generating bibliography, ", "please wait");
   if (DEBUG_AUTO)
     debug_automatic << "Generating bibliography"


### PR DESCRIPTION
The `bibliography` macro takes as second argument the name of a .bst file. However, it is possible to leave this argument blank. In that case BibTeX fails because it cannot find the (nonexistent) file `.bst`. Therefore, it is better to check whether the style is an empty string and if it is set it to the "tm-plain" style.

Ideally TeXmacs should not allow calling a macro of arity N with less than N arguments.