### PR TITLE
[SVN] Git: Fix for Windows

### DIFF
--- a/TeXmacs/progs/version/version-git.scm
+++ b/TeXmacs/progs/version/version-git.scm
@@ -28,7 +28,7 @@
          (git-dir (url-append dir ".git"))
          (pdir (url-expand (url-append dir ".."))))
     (cond ((url-directory? git-dir)
-           (string-replace (url->string dir) "\\" "/"))
+           (string-replace (url->system dir) "\\" "/"))
           ((== pdir dir) "/")
           (else (git-root pdir)))))
 
@@ -51,8 +51,8 @@
 ;; File status
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (tm-define (buffer-status name)
-  (let* ((path (url->string name))
-         (cmd (string-append (git-command path) " status --porcelain " path))
+  (let* ((path (url->system name))
+         (cmd (string-append (git-command name) " status --porcelain " path))
          (ret (eval-system cmd)))
     (cond ((> (string-length ret) 3) (string-take ret 2))
           ((file-exists? path) "  ")

--- a/TeXmacs/progs/version/version-tmfs.scm
+++ b/TeXmacs/progs/version/version-tmfs.scm
@@ -190,18 +190,6 @@
           (git-show-normal name)
           (git-show-merge name))))
 
-(tm-define (string->commit str name)
-  (if (string-null? str) '()
-      (with alist (string-split str #\nl)
-            (list (string-take (first alist) 20)
-                  (second alist)
-                  (third alist)
-                  ($link (tmfs-url-commit (fourth alist)
-                                          (if (string-null? name)
-                                              ""
-                                              (string-append "|" name)))
-                         (string-take (fourth alist) 7))))))
-
 (define (string-repeat str n)
   (do ((i 1 (1+ i))
        (ret "" (string-append ret str)))

--- a/TeXmacs/progs/version/version-tmfs.scm
+++ b/TeXmacs/progs/version/version-tmfs.scm
@@ -99,7 +99,7 @@
     (with h (version-history u)
             ($generic
              ($tmfs-title "History of "
-                          ($link (url->unix u)
+                          ($link (url->system u)
                                  ($verbatim (utf8->cork (url->system (url-tail u))))))
              ($when (not h)
                     "This file is not under version control.")


### PR DESCRIPTION
For Windows support, we should use `system->url` and `url->system`.