### PR TITLE
Sort and merge citations upon exporting to PDF

### DIFF
--- a/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
@@ -467,6 +467,11 @@
   ("1.6" "1.6")
   ("1.7" "1.7"))
 
+(define-preference-names "sort-merge-citations"
+  ("off" "Disabled")
+  ("on" "Enabled"))
+
+
 (tm-widget (pdf-preferences-widget)
   ===
   (bold (text "TeXmacs -> Pdf/Postscript"))
@@ -482,7 +487,10 @@
 		(get-boolean-preference "native postscript"))))
    (meti (hlist // (text "Expand beamer slides"))
       (toggle (set-boolean-preference "texmacs->pdf:expand slides" answer)
-	      (get-boolean-preference "texmacs->pdf:expand slides"))))
+	      (get-boolean-preference "texmacs->pdf:expand slides")))
+   (meti (hlist // (text "Sort and merge citations"))
+      (toggle (set-boolean-preference "sort-merge-citations" answer)
+              (get-boolean-preference "sort-merge-citations"))))
     (assuming (supports-native-pdf?)
       (aligned (meti (hlist // (text "Distill encapsulated Pdf files"))
 	(toggle (set-boolean-preference "texmacs->pdf:distill inclusion" answer)

--- a/TeXmacs/progs/texmacs/texmacs/tm-print.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-print.scm
@@ -86,21 +86,30 @@
   ("printer dpi" "600" notify-printer-dpi))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Printing wrapper for slides
+;; Printing wrapper
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(tm-define (sort-merge-citations?)
+  (get-boolean-preference "sort-merge-citations"))
+
 (tm-define (wrapped-print-to-file fname)
-  (if (screens-buffer?)
-      (let* ((cur (current-buffer))
-             (buf (buffer-new)))
-        (buffer-copy cur buf)
-        (buffer-set-master buf cur)
-        (switch-to-buffer buf)
-        (dynamic-make-slides)
-        (print-to-file fname)
-        (switch-to-buffer cur)
-        (buffer-close buf))
-      (print-to-file fname)))
+		   (cond ((screens-buffer?)
+	                  (let* ((cur (current-buffer))
+			              (buf (buffer-new)))
+                            (buffer-copy cur buf)
+                            (buffer-set-master buf cur)
+                            (switch-to-buffer buf)
+                            (dynamic-make-slides)
+                            (print-to-file fname)
+                            (switch-to-buffer cur)
+                            (buffer-close buf)))
+			 ((sort-merge-citations?)
+			  (begin
+			   (add-style-package "cite-sort")
+			   (print-to-file fname)
+			   (remove-style-package "cite-sort")
+                           (save-buffer)))
+			 (#t (print-to-file fname))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Printing commands

--- a/TeXmacs/progs/utils/cite/cite-sort.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort.scm
@@ -32,14 +32,17 @@
       (if (!= ret '(uninit)) ret ""))))
 
 (tm-define (cite-sort args)
-  ;; get a (tuple (tuple key_1 value_1) ... (tuple key_n value_n))
-  ;; and sort it according to values.
-  (:secure #t)
-  (let* ((args (map tree->stree (tree-children args)))
-         (keys (map expand-references (map caddr args)))
-         (tup (map list keys args))
-         (sorted-tup (list-sort tup compare-cite-keys))
-         ;; we should merge contiguous number series here...
-         (sorted-args (map cadr sorted-tup))
-         (ret `(concat ,@(list-intersperse sorted-args '(cite-sep)))))
-    ret))
+           ;; get a (tuple (tuple key_1 value_1) ... (tuple key_n value_n))
+	   ;; and sort it according to values.
+	   (:secure #t)
+	   (let* ((args (map tree->stree (tree-children args)))
+	          (keys (map expand-references (map caddr args)))
+		  (tup (map list keys args))
+		  (sorted-tup (list-sort tup compare-cite-keys))
+		  ;; we should merge contiguous number series here...
+		  (merge? (> (length sorted-tup) 2))
+		  (sorted-args (map cadr (if merge? (list (first sorted-tup) (last sorted-tup))
+                                           sorted-tup)))
+		  (sep (if merge? "--" '(cite-sep)))
+		  (ret `(concat ,@(list-intersperse sorted-args sep))))
+             ret))


### PR DESCRIPTION
When exporting to PDF one usually wants to merge contiguous citations, so that instead of [1,2,3,4] TeXmacs typesets [1-4]. The `cite-sort` package sorts the citations, but it does not merge them. I have implemented this functionality. 

Given the way citations currently work, it is not recommended to keep the cite-sort package activated while working on a document. The reason is that the `cite-sort` **macro** does not only affect how the `cite` macro is rendered, but it also affects its output. In my opinion, these two aspects should be separated. Then the cite-sort macro would only affect the appearance of a citation range.

Therefore, it is currently preferable to activate the cite-sort package before exporting to PDF and deactivate it afterwards. In order to automate this process I implemented a preference and modified the print-to-file wrapper so that it activates the package, prints the file and then deactivates the package.