### PR TITLE
[SVN] Clean up R plugin initialization

### DIFF
--- a/plugins/r/r/TeXmacs/R/TeXmacs.R
+++ b/plugins/r/r/TeXmacs/R/TeXmacs.R
@@ -26,14 +26,13 @@
 	assign("?",t.display.html.help, ,envir=as.environment("package:TeXmacs"))
 
 	assign("TeXmacsR.version","0.16",envir=as.environment("package:TeXmacs") )
-	motd=paste("TeXmacs to R interface version ",TeXmacsR.version,"\n\
-	Run start.view() to use graphics without x11()\
+	motd="Run start.view() to use graphics without x11()\
 	Use t.help.start() to view R documentation pages separately. Otherwise they are displayed in the buffer.\
 	\
-	Notice: if you want density graphs produced with image() to render much faster, use the option useRaster=T",sep="")
-	packageStartupMessage( paste(strsplit(motd," ")[[1]]," ")) 
+	Notice: if you want density graphs produced with image() to render much faster, use the option useRaster=T"
 
-    packageStartupMessage("TeXmacs to R interface version ",TeXmacsR.version,"\n") 
+        packageStartupMessage("TeXmacs to R interface version ",TeXmacsR.version,"\n") 
+	packageStartupMessage( paste(strsplit(motd," ")[[1]]," "))
 
 	if( as.numeric( version$minor )*0.0001 + as.numeric(
 version$major ) >= 2.0011 ) {

--- a/plugins/r/r/TeXmacs/R/TeXmacs.R
+++ b/plugins/r/r/TeXmacs/R/TeXmacs.R
@@ -26,10 +26,8 @@
 	assign("?",t.display.html.help, ,envir=as.environment("package:TeXmacs"))
 
 	assign("TeXmacsR.version","0.16",envir=as.environment("package:TeXmacs") )
-	motd="Run start.view() to use graphics without x11()\
-	Use t.help.start() to view R documentation pages separately. Otherwise they are displayed in the buffer.\
-	\
-	Notice: if you want density graphs produced with image() to render much faster, use the option useRaster=T"
+	motd="Run start.view() to use graphics without x11().\
+	Notice: if you want density plots produced with image() to render much faster, use the option useRaster=T"
 
         packageStartupMessage("TeXmacs to R interface version ",TeXmacsR.version,"\n") 
 	packageStartupMessage( paste(strsplit(motd," ")[[1]]," "))

--- a/plugins/r/src/tm_r.c
+++ b/plugins/r/src/tm_r.c
@@ -111,17 +111,8 @@ int N_data_begins = 0 ;
 
 
 
-char *DEFAULT_TEXMACS_SEND =  "\
-if( is.element(\"TeXmacs\", installed.packages()[,1]) ) \
-{library( TeXmacs); }\n \
-if( !is.element(\"TeXmacs\", installed.packages()[,1]) || \n\
-!exists(\"TeXmacsR.version\",where = as.environment(\"package:TeXmacs\")) || \n\
- as.numeric( get(\"TeXmacsR.version\",envir=as.environment(\"package:TeXmacs\")))\n <"TEXMACS_R_VERSION" ) { \n\
-	cur.dir=getwd(); setwd( tempdir() ); \n\
-	system(paste(\"R CMD build \",Sys.getenv(\"TEXMACS_PATH\"),\"/plugins/r/r/TeXmacs\",sep=\"\") );\n\
-	pack=list.files(pattern=\"TeXmacs.*gz\"); \n\
-    install.packages(pack,repos=NULL,type=\"source\");	\n\
-	library(TeXmacs) }\n" ;
+char *DEFAULT_TEXMACS_SEND = "source(paste(Sys.getenv(\"TEXMACS_PATH\"),\"/plugins/r/texmacs.r\",sep=\"\"))\n";
+
 
 // Add one more DATA_BEGIN, i.e. open bracket.
 #define B_DATA_BEGIN( TXB )					\

--- a/plugins/r/texmacs.r
+++ b/plugins/r/texmacs.r
@@ -1,0 +1,12 @@
+if( is.element("TeXmacs", installed.packages()[,1]) ) {library( TeXmacs); }
+
+if( !is.element("TeXmacs", installed.packages()[,1]) || 
+    !exists("TeXmacsR.version",where = as.environment("package:TeXmacs")) || 
+    as.numeric( get("TeXmacsR.version",envir=as.environment("package:TeXmacs"))) < 0.15 ) { 
+
+    cur.dir=getwd(); setwd( tempdir() );
+    system(paste("R CMD build ",Sys.getenv("TEXMACS_PATH"),"/plugins/r/r/TeXmacs",sep="") );
+    pack=list.files(pattern="TeXmacs.*gz"); 
+    install.packages(pack,repos=NULL,type="source");
+    library(TeXmacs)
+}


### PR DESCRIPTION
Currently when an R session is initialized the R TeXmacs plugin injects the R code that checks for the installation of the TeXmacs R package, thus polluting the R session in TeXmacs. I saved that code to a file so that the initialization of the plugin only requires sending one line to R.

I also fixed the banner. See the commits.