### PR TITLE
Set default FLAGS to contain debug symbols

### DIFF
--- a/configure
+++ b/configure
@@ -3031,10 +3031,10 @@ _ACEOF
 # Checks for C++ compiler
 #--------------------------------------------------------------------
 
-# define CFLAGS else it would assigned at -g -O2 later by autoconf
+# set FLAGS without -O2 if it is undefined, otherwise it would assigned at -g -O2 later by autoconf
 # but keep previous value if any
-CFLAGS=${CFLAGS:=""}
-CXXFLAGS=${CXXFLAGS:=""}
+CFLAGS=${CFLAGS:="-g"}
+CXXFLAGS=${CXXFLAGS:="-g"}
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'

--- a/configure.in
+++ b/configure.in
@@ -26,10 +26,10 @@ TM_SUBVERSION
 # Checks for C++ compiler
 #--------------------------------------------------------------------
 
-# define CFLAGS else it would assigned at -g -O2 later by autoconf
+# set FLAGS without -O2 if it is undefined, otherwise it would assigned at -g -O2 later by autoconf
 # but keep previous value if any
-CFLAGS=${CFLAGS:=""}
-CXXFLAGS=${CXXFLAGS:=""}
+CFLAGS=${CFLAGS:="-g"}
+CXXFLAGS=${CXXFLAGS:="-g"}
 
 AC_PROG_CC([clang gcc])
 AC_PROG_CXX([clang++ g++])


### PR DESCRIPTION
Previously, the default FLAGS is set to be empty. It seems better to contain `-g` which is useful for both bug reports and debugging.