### PR TITLE
Fix Chinese punctuations too wide

### DIFF
--- a/src/Graphics/Fonts/font_spacing.cpp
+++ b/src/Graphics/Fonts/font_spacing.cpp
@@ -86,10 +86,6 @@ font_rep::get_spacing_entry (int mode, tree t, int i) {
     if (t == "default" || t == "old" || t == "wide")
       return space (-(spc->min>>2), 0, spc->max>>1);
     return get_spacing_entry (mode, t, i, "cjk-period");
-  case SPC_CJK_WIDE_PERIOD:
-    if (t == "default" || t == "old" || t == "wide")
-      return spc + extra;
-    return get_spacing_entry (mode, t, i, "cjk-wide-period");
   case SPC_HALF:
     if (t == "default" || t == "wide") {
       if (mode >= 0) return space (spc->min>>2, spc->def>>2, spc->max>>2);

--- a/src/System/Language/impl_language.hpp
+++ b/src/System/Language/impl_language.hpp
@@ -25,7 +25,6 @@ extern text_property_rep tp_period_rep;
 extern text_property_rep tp_cjk_normal_rep;
 extern text_property_rep tp_cjk_no_break_rep;
 extern text_property_rep tp_cjk_period_rep;
-extern text_property_rep tp_cjk_wide_period_rep;
 extern text_property_rep tp_cjk_no_break_period_rep;
 extern text_property_rep tp_half_rep;
 extern text_property_rep tp_operator_rep;

--- a/src/System/Language/language.cpp
+++ b/src/System/Language/language.cpp
@@ -43,8 +43,6 @@ text_property_rep tp_cjk_no_break_rep
   (TP_CJK_NO_BREAK, SPC_NONE, SPC_CJK_NORMAL, 0, HYPH_INVALID);
 text_property_rep tp_cjk_period_rep
   (TP_CJK_PERIOD, SPC_NONE, SPC_CJK_PERIOD, HYPH_INVALID, 0);
-text_property_rep tp_cjk_wide_period_rep
-  (TP_CJK_PERIOD, SPC_NONE, SPC_CJK_WIDE_PERIOD, HYPH_INVALID, 0);
 text_property_rep tp_cjk_no_break_period_rep
   (TP_CJK_PERIOD, SPC_NONE, SPC_CJK_PERIOD, HYPH_INVALID, HYPH_INVALID);
 text_property_rep tp_half_rep

--- a/src/System/Language/language.hpp
+++ b/src/System/Language/language.hpp
@@ -36,7 +36,7 @@ RESOURCE(language);
 #define TP_CJK_NORMAL         9
 #define TP_CJK_NO_BREAK      10
 #define TP_CJK_PERIOD        11
-#define TP_CJK_WIDE_PERIOD   12
+// #define TP_CJK_WIDE_PERIOD   12 (DEPRECATED)
 #define TP_OPERATOR          13
 #define TP_SHORTOP           14
 #define TP_OTHER             15
@@ -49,7 +49,7 @@ RESOURCE(language);
 #define SPC_TINY              5
 #define SPC_CJK_NORMAL        6
 #define SPC_CJK_PERIOD        7
-#define SPC_CJK_WIDE_PERIOD   8
+// #define SPC_CJK_WIDE_PERIOD   8 (DEPRECATED)
 #define SPC_HALF              9
 #define SPC_OPERATOR         10
 #define SPC_WIDEOP           11

--- a/src/System/Language/text_language.cpp
+++ b/src/System/Language/text_language.cpp
@@ -289,7 +289,6 @@ ucs_text_language_rep::hyphenate (
 
 struct oriental_language_rep: language_rep {
   hashmap<string,bool> punct;
-  hashmap<string,bool> wide_punct;
   oriental_language_rep (string lan_name);
   text_property advance (tree t, int& pos);
   array<int> get_hyphens (string s);
@@ -339,20 +338,6 @@ oriental_language_rep::oriental_language_rep (string lan_name):
   punct ("<#FF1A>")= true;
   punct ("<#FF1B>")= true;
   punct ("<#FF1F>")= true;
-
-  wide_punct ("<#3001>")= true;
-  wide_punct ("<#ff01>")= true;
-  wide_punct ("<#ff0c>")= true;
-  wide_punct ("<#ff0e>")= true;
-  wide_punct ("<#ff1a>")= true;
-  wide_punct ("<#ff1b>")= true;
-  wide_punct ("<#ff1f>")= true;
-  wide_punct ("<#FF01>")= true;
-  wide_punct ("<#FF0C>")= true;
-  wide_punct ("<#FF0E>")= true;
-  wide_punct ("<#FF1A>")= true;
-  wide_punct ("<#FF1B>")= true;
-  wide_punct ("<#FF1F>")= true;
 }
 
 text_property
@@ -387,8 +372,6 @@ oriental_language_rep::advance (tree t, int& pos) {
   if (punct->contains (c)) {
     if (punct->contains (x) || pos == N(s))
       return &tp_cjk_no_break_period_rep;
-    else if (wide_punct->contains (c))
-      return &tp_cjk_wide_period_rep;
     else return &tp_cjk_period_rep;
   }
   else {


### PR DESCRIPTION
Chinese punctuation characters shouldn't be widened by simply adding extra space behind it, which will lead to too wide punctuations, for `，` `：` etc. These characters are already full-width in fonts that support CJK. Review needed.