### PR TITLE
[SVN] Fix SimSun not found and italic/typewriter of SimSun

### DIFF
--- a/TeXmacs/fonts/font-database.scm
+++ b/TeXmacs/fonts/font-database.scm
@@ -1121,7 +1121,7 @@
 ((SignPainter-HouseScript Regular) ((SignPainter.otf 0 163412)))
 ((Silom Regular) ((Silom.ttf 0 281848) (Silom.ttf 0 288864) (Silom.ttf 0 289492)))
 ((SimHei Regular) ((simhei.ttf 0 9751960)))
-((SimSun Regular) ((simsun.ttf 0 10499104)))
+((SimSun Regular) ((simsun.ttc 0 10499104)))
 ((Sinhala\ MN Bold) ((Sinhala\ MN.ttc 1 1466440) (Sinhala\ MN.ttc 1 1467868)))
 ((Sinhala\ MN Regular) ((Sinhala\ MN.ttc 0 1466440) (Sinhala\ MN.ttc 0 1467868)))
 ((Sinhala\ Sangam\ MN Bold) ((Sinhala\ Sangam\ MN.ttc 1 642408) (Sinhala\ Sangam\ MN.ttc 1 642756)))

--- a/TeXmacs/fonts/font-substitutions.scm
+++ b/TeXmacs/fonts/font-substitutions.scm
@@ -13,6 +13,8 @@
 ((Sazanami\ Mincho sansserif) (Sazanami\ Gothic))
 ((SimSun bold) (SimHei))
 ((SimSun sansserif) (SimHei))
+((SimSun italic) (KaiTi_GB2312))
+((SimSun typewriter) (FangSong_GB2312))
 ((STSong bold) (STHeiti))
 ((STSong sansserif) (STHeiti))
 ((STSong italic) (STKaiti))


### PR DESCRIPTION
* Corrected the font name of SimSun
* Italic and typewriter of SimSun will be substituted with KaiTi and FangSong, as CTEX will do.