### PR TITLE
[SVN] remove "octave -v"

### DIFF
--- a/plugins/octave/bin/tm_octave.bat
+++ b/plugins/octave/bin/tm_octave.bat
@@ -2,7 +2,7 @@
 rem denis RAUX LIX 2013
 rem a simple trick to
 set /p DUMMY="verbatim:" <nul
-octave -v
+rem octave -v
 rem cd $TEXMACS_PATH/plugins/octave/octave; exec octave -qi tm-start.oct
 cd %TEXMACS_PATH%\plugins\octave\octave
-octave -qi tm-start.oct
+octave -qi tm-start.m


### PR DESCRIPTION
"octave -v" dose not return in Windows system, and this cause busy get stuck.