### PR TITLE
[SVN] Append Homebrewed Qt5 path to CMake search prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,6 +547,10 @@ if (TEXMACS_GUI MATCHES "Qt.*")
     )
     include (${QT_USE_FILE})
   else (TEXMACS_GUI STREQUAL "Qt4")
+    # Homebrew installs Qt5 in /usr/local/opt/qt5
+    if (APPLE AND EXISTS /usr/local/opt/qt5)
+      list (APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+    endif()
     find_package (Qt5 COMPONENTS Core Gui Widgets PrintSupport REQUIRED)
     set (QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::PrintSupport)
     set (TeXmacs_Include_Dirs


### PR DESCRIPTION
I had some problems while trying to compile TeXmacs in macOS with Qt5. Apparently, it is a recurrent problem in homebrew-installed `qt` that Homebrew installs it in a non-expected path by the CMake config files (https://github.com/Homebrew/homebrew-core/issues/8392).

This PR commits the solution proposed in https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-325226494 and ensures that Qt5 can be found by CMake.

I now manage to build it but still got problems when launching it.