### PR TITLE
Change the style of Definitions

### DIFF
--- a/TeXmacs/packages/environment/env-theorem.ts
+++ b/TeXmacs/packages/environment/env-theorem.ts
@@ -38,8 +38,6 @@
 
   <new-theorem|axiom|Axiom>
 
-  <new-theorem|definition|Definition>
-
   <new-theorem|notation|Notation>
 
   <new-theorem|conjecture|Conjecture>
@@ -49,6 +47,8 @@
   <new-remark|remark|Remark>
 
   <new-remark|example|Example>
+    
+  <new-remark|definition|Definition>
 
   <new-remark|note|Note>
 


### PR DESCRIPTION
There are two reasons for such change:
1. Convention: most documents render Definitions roman instead of italic, but only italicize the terminology to be defined.
2. Coherence: there exists a macro `\dfn` in TeXmacs to underline the terminology. If I use that with definition environment, the effect is invisible. See the following TeXmacs Scheme code: `(definition (document (concat "An integer " (math "n") " is called " (dfn "non-negative") " if " (math "n<geq>0") ".")))`