### PR TITLE
Fix: copy and paste images

### DIFF
--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -359,8 +359,8 @@ qt_gui_rep::set_selection (string key, tree t,
         //selection = c_string (sh);
         //md->setHtml (selection);
         //tm_delete_array (selection);
-      
-      selection = c_string (sv);
+      if (!is_empty (sv))
+        selection = c_string (sv);
     }
     
     string enc = get_preference ("texmacs->verbatim:encoding");


### PR DESCRIPTION
Under GNU/Linux, when copying and pasting images, `s` is the selected doc snippet, `sv` is empty.

## Ref
+ https://lists.gnu.org/archive/html/texmacs-dev/2020-10/msg00027.html