### PR TITLE
Fixed 4 typos in menus

### DIFF
--- a/TeXmacs/progs/education/edu-menu.scm
+++ b/TeXmacs/progs/education/edu-menu.scm
@@ -155,7 +155,7 @@
   (:require (style-has? "exam-style"))
   ("Class" (make-doc-data-element 'doc-exam-class))
   ("Date" (make-doc-data-element 'doc-exam-date))
-  ("Miscellanous" (make-doc-data-element 'doc-misc))
+  ("Miscellaneous" (make-doc-data-element 'doc-misc))
   ("Note" (make-doc-data-element 'doc-note)))
 
 (tm-menu (focus-title-hidden-menu)

--- a/TeXmacs/progs/fonts/font-old-menu.scm
+++ b/TeXmacs/progs/fonts/font-old-menu.scm
@@ -385,7 +385,7 @@
 	      ("Bold" (make-with "math-font-series" "bold"))))
       (-> "Shape"
 	  ("Normal" (make-with "math-font-shape" "normal"))
-	  ("Upight" (make-with "math-font-shape" "right"))))
+	  ("Upright" (make-with "math-font-shape" "right"))))
   (if (not (real-math-font? (get-env "math-font")))
       (-> "Variant"
 	  ("Roman" (make-with "math-font-family" "mr"))

--- a/TeXmacs/progs/generic/insert-menu.scm
+++ b/TeXmacs/progs/generic/insert-menu.scm
@@ -58,7 +58,7 @@
                 ---
                 (group "Decomposed")
                 ("Parenthesis" (make 'render-cite))
-                ("Abreviated authors" (make 'cite-author-link))
+                ("Abbreviated authors" (make 'cite-author-link))
                 ("Full author list" (make 'cite-author*-link))
                 ("Year" (make 'cite-year-link))
                 ("Invisible" (make 'nocite))))

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -786,7 +786,7 @@
   ("Affiliation" (make-author-data-element 'author-affiliation))
   ("Email" (make-author-data-element 'author-email))
   ("Homepage" (make-author-data-element 'author-homepage))
-  ("Miscellanous" (make-author-data-element 'author-misc))
+  ("Miscellaneous" (make-author-data-element 'author-misc))
   ("Note" (make-author-data-element 'author-note)))
 
 (tm-menu (focus-author-icons)


### PR DESCRIPTION
While I was working on the updated italian dictionary, I encountered some terms that seemd like typos somewhere.
Three of these terms still showed up in asource code search:
"Abreviated authors", "Miscellanous" (twice) and "Upight".
Of course all these (as well as "custum tab") show up in all dictionaries, but I haven;t touched that part.