### PR TITLE
Don't build tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,11 +795,15 @@ endforeach ()
 ### Testing
 ### --------------------------------------------------------------------
 
-include (CTest)
-find_package(Qt5Test REQUIRED)
-enable_testing ()
-add_subdirectory (tests)
-# add_subdirectory (misc/benchmark)
+option (BUILD_TESTS "Build unit tests" OFF)
+
+if (BUILD_TESTS)
+  include (CTest)
+  find_package(Qt5Test REQUIRED)
+  enable_testing ()
+  add_subdirectory (tests)
+  # add_subdirectory (misc/benchmark)
+endif (BUILD_TESTS)
 
 ### ---------------------------------------------------------------------
 ### VSCode Support


### PR DESCRIPTION
The commit adds an option to build tests, which defaults to off (the tests are quite large when built). @darcy-shen 