### PR TITLE
Fixes here and there for s7 scheme on Windows 10

### DIFF
--- a/TeXmacs/progs/init-texmacs-s7.scm
+++ b/TeXmacs/progs/init-texmacs-s7.scm
@@ -11,6 +11,19 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(when (equal? (scheme-dialect) "s7")
+  (begin
+    ;; Preallocate memory for speed.
+    (set! (*s7* 'heap-size) 1024000)
+    (set! (*s7* 'gc-resize-heap-by-4-fraction) 0.25)
+    (set! (*s7* 'gc-resize-heap-fraction) 0.5)
+    ;; For gc activity
+    ;; (set! (*s7* 'gc-stats) 1)
+    ;; For heap stack activity
+    ;; (set! (*s7* 'gc-stats) 2)
+    ;; For both gc and heap activity
+    (set! (*s7* 'gc-stats) 3)
+    (set! (*s7* 'profile) 2)))
 
 ;; S7 macros are not usual macros...
 (define define-macro define-expansion)
@@ -61,7 +74,7 @@
 (display "Booting TeXmacs kernel functionality\n")
 (load (url-concretize "$TEXMACS_PATH/progs/kernel/boot/boot-s7.scm"))
 
-(inherit-modules (kernel boot compat-s7) (kernel boot abbrevs)
+(inherit-modules (kernel boot compat-s7) (kernel boot abbrevs-s7)
                  (kernel boot debug) (kernel boot srfi)
                  (kernel boot ahash-table) (kernel boot prologue))
 (inherit-modules (kernel library base) (kernel library list)
@@ -529,3 +542,8 @@
                   ;(quit-TeXmacs)
                   ))))))))))))
 
+;; iota is not implemented for s7.
+(tm-define (iota n)
+  (let loop ((count (1- n)) (result '()))
+    (if (< count 0) result
+        (loop (1- count) (cons count result)))))

--- a/TeXmacs/progs/kernel/boot/abbrevs-s7.scm
+++ b/TeXmacs/progs/kernel/boot/abbrevs-s7.scm
@@ -1,0 +1,230 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : abbrevs.scm
+;; DESCRIPTION : useful abbreviations
+;; COPYRIGHT   : (C) 2003  Joris van der Hoeven
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (kernel boot abbrevs-s7))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Common notations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public == equal?)
+(define-public (!= x y) (not (equal? x y)))
+
+(define-public (nsymbol? x) (not (symbol? x)))
+(define-public (nstring? x) (not (string? x)))
+(define-public (nnull? x) (not (null? x)))
+(define-public (npair? x) (not (pair? x)))
+(define-public (nlist? x) (not (list? x)))
+(define-public (nnot x) (not (not x)))
+(define-public-macro (toggle! x) `(set! ,x (not ,x)))
+(define-public (safe-car l) (and (pair? l) (car l)))
+(define-public (safe-cdr l) (and (pair? l) (cdr l)))
+
+(define-public (list-1? x) (and (pair? x) (null? (cdr x))))
+(define-public (nlist-1? x) (not (list-1? x)))
+(define-public (list-2? x) (and (list? x) (= (length x) 2)))
+(define-public (nlist-2? x) (not (list-2? x)))
+(define-public (list-3? x) (and (list? x) (= (length x) 3)))
+(define-public (nlist-3? x) (not (list-3? x)))
+(define-public (list-4? x) (and (list? x) (= (length x) 4)))
+(define-public (nlist-4? x) (not (list-4? x)))
+(define-public (list>0? x) (and (pair? x) (list? x)))
+(define-public (nlist>0? x) (not (list>0? x)))
+(define-public (list>1? x) (and (list? x) (> (length x) 1)))
+(define-public (nlist>1? x) (not (list>1? x)))
+
+(define-public (in? x l) (not (not (member x l))))
+(define-public (nin? x l) (not (member x l)))
+(define-public (cons-new x l) (if (in? x l) l (cons x l)))
+
+(define-public (always? . l) #t)
+(define-public (never? . l) #f)
+(define-public (root? t) (== (reverse (tree-ip t)) (buffer-path)))
+(define-public (nroot? t) (!= (reverse (tree-ip t)) (buffer-path)))
+(define-public (leaf? t) (== (tree-ip t) (cdr (reverse (cursor-path)))))
+(define-public (nleaf? t) (!= (tree-ip t) (cdr (reverse (cursor-path)))))
+(define-public (true? . l) #t)
+(define-public (false? . l) #f)
+
+(provide-public (identity x) x)
+(provide-public (ignore . l) (noop))
+(provide-public (negate pred?) (lambda x (not (apply pred? x))))
+
+(define-public (keyword->string x)
+  (symbol->string (keyword->symbol x)))
+(define-public (string->keyword x)
+  (symbol->keyword (string->symbol x)))
+(define-public (keyword->number x)
+  (string->number (string-tail (symbol->string (keyword->symbol x)) 1)))
+(define-public (number->keyword x)
+  (symbol->keyword (string->symbol (string-append "%" (number->string x)))))
+
+(define-public (save-object file value)
+  (call-with-output-file (url-materialize file "") (lambda (port)
+    (let-temporarily (((*s7* 'print-length) 9223372036854775807)) (write value port)))))
+
+(define-public (load-object file)
+  (let ((r (call-with-input-file (url-materialize file "r") (lambda (port) (read port)))))
+        (if (eof-object? r) '() r)))
+
+(define-public (persistent-ref dir key)
+  (and (persistent-has? dir key)
+       (persistent-get dir key)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Common programming constructs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public-macro (with var val . body)
+  (if (pair? var)
+      `(apply (lambda ,var ,@body) ,val)
+      `(let ((,var ,val)) ,@body)))
+
+(define-public-macro (with-define fun fun-body . body)
+  `(let ((,(car fun) (lambda ,(cdr fun) ,fun-body)))
+     ,@body))
+
+;; https://ccrma.stanford.edu/software/snd/snd/s7.html#multiplevalues: One problem with this way of handling multiple values involves cases where you can't tell whether an expression will return multiple values. Then you have, for example, (let ((val (expr)))...) and need to accept either a normal single value from expr, or one member of the possible set of multiple values. In lint.scm, I'm currently handling this with lambda: (let ((val ((lambda args (car args)) (expr))))...), but this feels kludgey. CL has nth-value which appears to do "the right thing" in this context; perhaps s7 needs it too.
+;; The example the author gave isn't what this macro is trying to achieve, which is annoying
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;; old code below ;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; (define-public-macro (with-global var val . body)
+;;   (let ((old (gensym)) (new (gensym)))
+;;     `(let ((,old ,var))
+;;        (set! ,var ,val)
+;;        (let ((,new (begin ,@body)))
+;;          (set! ,var ,old)
+;;          ,new))))
+
+(define-public-macro (with-global var val . body)
+  (let ((old (gensym)) (new (gensym)))
+    `(let ((,old ,var))
+       (set! ,var ,val)
+       (let ((,new (list (begin ,@body))))
+         (set! ,var ,old)
+         (apply-values ,new)))))
+
+
+(define-public-macro (and-with var val . body)
+  `(with ,var ,val
+     (and ,var (begin ,@body))))
+
+(define-public-macro (with-result result . body)
+  `(let* ((return ,result)
+          (dummy (begin ,@body)))
+     return))
+
+(define (range-list start end delta)
+  (if (< start end)
+      (cons start (range-list (+ start delta) end delta))
+      '()))
+
+(define (range-list* start end delta)
+  (if (<= start end)
+      (cons start (range-list* (+ start delta) end delta))
+      '()))
+
+(define-public (.. start end . delta)
+  (if (null? delta)
+      (range-list start end 1)
+      (range-list start end (car delta))))
+
+(define-public (... start end . delta)
+  (if (null? delta)
+      (range-list* start end 1)
+      (range-list* start end (car delta))))
+
+(define-public-macro (for what . body)
+  (let ((n (length what)))
+    (cond ((== n 2)
+           ;; range over values of a list
+           `(for-each (lambda (,(car what)) ,@body)
+                      ,(cadr what)))
+          ((== n 3)
+           ;; range over values from start to end with step 1
+           `(do ((,(car what) ,(cadr what) (+ ,(car what) 1)))
+                ((>= ,(car what) ,(caddr what)) (noop))
+              ,@body))
+          ((== n 4)
+           ;; range over values from start to end with step
+           `(if (> ,(cadddr what) 0)
+                (do ((,(car what) ,(cadr what) (+ ,(car what) ,(cadddr what))))
+                    ((>= ,(car what) ,(caddr what)) (noop))
+                  ,@body)
+                (do ((,(car what) ,(cadr what) (+ ,(car what) ,(cadddr what))))
+                    ((<= ,(car what) ,(caddr what)) (noop))
+                  ,@body)))
+          ((== n 5)
+           ;; range over values from start to end with step and comparison
+           `(do ((,(car what) ,(cadr what) (+ ,(car what) ,(cadddr what))))
+                ((not (,(car (cddddr what)) ,(car what) ,(caddr what))) (noop))
+              ,@body))
+          (else '(noop)))))
+
+(define-public-macro (repeat n . body)
+  (let ((x (gensym)))
+    `(for (,x 0 ,n) ,@body)))
+
+(define-public-macro (twice . body)
+  `(begin ,@body ,@body))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Small rewritings on top of C++ interface
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (path->tree p)
+  (and (path-exists? p) (cpp-path->tree p)))
+
+(define-public selection-active? selection-active-any?)
+
+(define-public (selection-active-non-small?)
+  (and (selection-active?)
+       (not (selection-active-small?))))
+
+(define-public (selection-active-large?)
+  (and (selection-active?)
+       (not (selection-active-small?))
+       (not (selection-active-table?))))
+
+(define-public (go-to p)
+  (let* ((r (buffer-path))
+         (lp (length p))
+         (lr (length r)))
+    (and (or (and (<= lr lp) (== (sublist p 0 lr) r))
+             (and-with buf (path->buffer p)
+               (switch-to-buffer buf) #t))
+         (go-to-path p))))
+
+(define-public (choose-file fun title type . opts)
+  (when (null? opts)
+    (with prompt (cond ((string-starts? title "Save") "Save as:")
+		       ((string-starts? title "Export") "Export as:")
+		       ((== title "Select database") "Selected database:")
+		       (else ""))
+      (set! opts (list prompt))))
+  (when (null? (cdr opts))
+    (with u (buffer-get-master (current-buffer))
+      (set! opts (list (car opts) u))))
+  (cpp-choose-file fun title type (car opts) (cadr opts)))
+
+(define-public (alt-windows-delete l)
+  (for-each alt-window-delete l))
+
+(define-public (qt4-gui?) (== (gui-version) "qt4"))
+(define-public (qt4-or-later-gui?) (in? (gui-version) (list "qt4" "qt5" "qt6")))
+(define-public (qt5-gui?) (== (gui-version) "qt5"))
+(define-public (qt5-or-later-gui?) (in? (gui-version) (list "qt5" "qt6")))
+(define-public (qt6-gui?) (== (gui-version) "qt6"))
+(define-public (qt6-or-later-gui?) (in? (gui-version) (list "qt6")))

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -71,8 +71,11 @@ Q_IMPORT_PLUGIN(qico)
 Q_IMPORT_PLUGIN(qsvg)
 #endif
 
-#ifdef WIN32 
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+#ifdef WIN32
+// https://github.com/atomlong/mingw-w64-qt5-base-static
+// can't compile this through msys2-ucrt; linking error.
+// commenting this works fine for non-static msys2 Qt5.
+// Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 #endif
 #ifdef QT_MAC_USE_COCOA
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
@@ -875,7 +878,7 @@ qt_gui_rep::update () {
   
   time_t delay = delayed_commands.lapse - texmacs_time();
   if (needing_update) delay = 0;
-  else                delay = max (0, min (std_delay, delay));
+  else                delay = max (0, min (std_delay, static_cast<int>(delay)));
   if (postpone_treatment) delay= 9; // NOTE: force occasional display
  
   updatetimer->start (delay);

--- a/src/Plugins/Windows/nowide/cstdio.hpp
+++ b/src/Plugins/Windows/nowide/cstdio.hpp
@@ -144,7 +144,7 @@ inline DIR* opendir(char const *name)
     return _wopendir (wname.c_str());
 }
 
-inline char* readir_entry(DIR* dir)
+inline string readir_entry(DIR* dir)
 {
   struct _wdirent *wentry;
   wentry = _wreaddir (dir);
@@ -152,14 +152,16 @@ inline char* readir_entry(DIR* dir)
 	     && (0 == wcscmp (wentry->d_name, L".") ||
 		 0 == wcscmp (wentry->d_name, L"..")))
 	     wentry = _wreaddir (dir);
-  if (wentry == NULL) return NULL;
+  if (wentry == NULL) return string("");
   else { 
-  stackstring entry;
+    stackstring entry;
     if(!entry.convert(wentry->d_name) ) {
         errno = EINVAL;
-        return NULL;
+        return string("");
     }
-    else return entry.c_str();
+    else {
+      return string(entry.c_str());
+    }
   }
 } 
 

--- a/src/Scheme/S7/s7_tm.cpp
+++ b/src/Scheme/S7/s7_tm.cpp
@@ -239,6 +239,7 @@ static s7_pointer free_blackbox (s7_scheme *sc, s7_pointer obj)
 
 static s7_pointer mark_blackbox (s7_scheme *sc, s7_pointer obj)
 {
+  return (NULL);
 }
 
 static s7_pointer blackbox_is_equal(s7_scheme *sc, s7_pointer args)

--- a/src/Scheme/S7/s7_tm.cpp
+++ b/src/Scheme/S7/s7_tm.cpp
@@ -232,10 +232,13 @@ static s7_pointer free_blackbox (s7_scheme *sc, s7_pointer obj)
 {
   blackbox *ptr = (blackbox *) s7_c_object_value (obj);
   tm_delete (ptr);
+  // Don't remove this, segmentation error could happen :)
+  return (NULL);
 }
 
 static s7_pointer mark_blackbox (s7_scheme *sc, s7_pointer obj)
 {
+  return (NULL);
 }
 
 static s7_pointer blackbox_is_equal(s7_scheme *sc, s7_pointer args)

--- a/src/System/Files/file.cpp
+++ b/src/System/Files/file.cpp
@@ -536,9 +536,14 @@ read_directory (url u, bool& error_flag) {
   array<string> dir;
   #ifdef OS_MINGW
   while (true) {
-    const char* nextname =  nowide::readir_entry (dp);
-    if (nextname==NULL) break;
-    dir << string (nextname);
+    // const char* nextname =  nowide::readir_entry (dp);
+    string nextname = nowide::readir_entry (dp);
+    // nowide::stackstring dir_entry = nowide::readir_entry (dp);
+    // const char* nextname = dir_entry.c_str();
+    
+    if (N(nextname) == 0) break;
+    dir << nextname;
+    // cout << "nowide::readir_entry() " << dir << '\n';
   #else
   struct dirent* ep;
   while (true) {


### PR DESCRIPTION
1. Memory tuning for s7 (please take a look at the comments and the scheme code I added).
2. I wasn't able to build with leaving Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin) in the code there. And I don't know how to resolve it for msys2-ucrt build.
3. I think we can even change the code in file.cpp that relies on unix api to Qt5 on Windows; we already depend on it anyway and it might even allow us to build TeXmacs using visual studio's toolchain, which has various handy profilers that can help us evaluate performance and pinpoint memory issues.