### PR TITLE
Rewrite of the Python plugin and protocol

### DIFF
--- a/plugins/tmpy/capture.py
+++ b/plugins/tmpy/capture.py
@@ -35,8 +35,7 @@ class CaptureStdout:
     def capture (code, env, filename):
         with CaptureStdout() as capt:
             try:
-                eval (compile (code, filename, 'exec'), env)
+                ret = eval (compile (code, filename, 'exec'), env)
             except Exception as e:
                 traceback.print_exc (file = os.sys.stdout, limit = 0)
-            return capt.getOutput()
-
+            return ret, capt.getOutput()

--- a/plugins/tmpy/capture.py
+++ b/plugins/tmpy/capture.py
@@ -35,7 +35,7 @@ class CaptureStdout:
     def capture (code, env, filename):
         with CaptureStdout() as capt:
             try:
-                ret = eval (compile (code, filename, 'exec'), env)
+                eval (compile (code, filename, 'exec'), env)
             except Exception as e:
                 traceback.print_exc (file = os.sys.stdout, limit = 0)
-            return ret, capt.getOutput()
+            return capt.getOutput()

--- a/plugins/tmpy/postscript.py
+++ b/plugins/tmpy/postscript.py
@@ -94,7 +94,7 @@ def ps_out (out):
     elif 'read' in dir(out):
         data = out.read()
 
-    return PSOutDummy(texmacs_escape(data).decode())
+    return PSOutDummy(data.decode())
 
 pdf_out_tmp_file = "pdf_out_" + str(os.getpid()) + ".pdf"
 if (platform.system() == "Windows"):

--- a/plugins/tmpy/protocol.py
+++ b/plugins/tmpy/protocol.py
@@ -23,18 +23,19 @@ DATA_COMMAND = chr(16)
 
 def data_begin():
     """Signal the beginning of data to TeXmacs."""
-    os.sys.stdout.write(chr(2))
+    os.sys.stdout.write(DATA_BEGIN)
 
 
 def data_end():
     """Signal the end of data to TeXmacs."""
-    os.sys.stdout.write(chr(5))
+    os.sys.stdout.write(DATA_END)
     os.sys.stdout.flush()
 
 
-def texmacs_escape (data):
-    return data.replace(DATA_BEGIN.encode(), (DATA_ESCAPE + DATA_BEGIN).encode()) \
-               .replace(DATA_END.encode(), (DATA_ESCAPE + DATA_END).encode())
+def texmacs_escape(data):
+    return data.replace(DATA_ESCAPE, DATA_ESCAPE + DATA_ESCAPE) \
+               .replace(DATA_BEGIN, DATA_ESCAPE + DATA_BEGIN) \
+               .replace(DATA_END, DATA_ESCAPE + DATA_END)
 
 
 def flush_any (out_str):
@@ -43,7 +44,7 @@ def flush_any (out_str):
     Output results back to TeXmacs, with the DATA_BEGIN,
     DATA_END control characters."""
     data_begin()
-    os.sys.stdout.write(out_str)
+    os.sys.stdout.write(texmacs_escape(out_str))
     data_end()
 
 def flush_verbatim(content):
@@ -73,9 +74,9 @@ def flush_ps(content):
     flush_any ("ps:" + content)
 
 def flush_err(content):
-    os.sys.stderr.write(chr(2))
-    os.sys.stderr.write("utf8:" + content)
-    os.sys.stderr.write(chr(5))
+    os.sys.stderr.write(DATA_BEGIN)
+    os.sys.stderr.write("verbatim:" + content)
+    os.sys.stderr.write(DATA_END)
     os.sys.stderr.flush() 
 
 def get_plugin_path(name):

--- a/plugins/tmpy/protocol.py
+++ b/plugins/tmpy/protocol.py
@@ -13,7 +13,6 @@
 ## in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 
 import os
-from os.path import exists
 
 DATA_BEGIN = chr(2)
 DATA_END = chr(5)
@@ -47,7 +46,12 @@ def flush_any (out_str):
     os.sys.stdout.write(texmacs_escape(out_str))
     data_end()
 
+# see src/Data/Convert/Generic/input.cpp
+
 def flush_verbatim(content):
+    flush_any ("verbatim:" + content)
+    
+def flush_utf8(content):
     flush_any ("utf8:" + content)
 
 def flush_newline (n = 1):
@@ -73,16 +77,25 @@ def flush_file(path):
 def flush_ps(content):
     flush_any ("ps:" + content)
 
+def flush_html(content):
+    flush_any ("html:" + content)
+
+def flush_math(content):
+    flush_any ("math:" + content)
+
+def flush_bibtex(content):
+    flush_any ("bibtex:" + content)
+
+def flush_texmacs(content):
+    flush_any ("texmacs:" + content)
+
+def flush_xformat(content,format):
+    # XFORMAT accepts any format that has a "parse-XXXX-snippet" function
+    # This could be defined in TeXmacs by the plugin using flush_scheme
+    flush_any (format + ":" + content)
+
 def flush_err(content):
     os.sys.stderr.write(DATA_BEGIN)
     os.sys.stderr.write("verbatim:" + content)
     os.sys.stderr.write(DATA_END)
     os.sys.stderr.flush() 
-
-def get_plugin_path(name):
-    the_home_path = os.getenv("TEXMACS_HOME_PATH").replace("\\", "/") + "/plugins/" + name
-    the_sys_path = os.getenv("TEXMACS_PATH").replace("\\", "/") + "/plugins/" + name
-    if (exists(the_home_path)):
-        return the_home_path
-    else:
-        return the_sys_path

--- a/plugins/tmpy/protocol.py
+++ b/plugins/tmpy/protocol.py
@@ -7,6 +7,7 @@
 ##               (C) 2012  Adrian Soto
 ##               (C) 2014  Miguel de Benito Delgado, mdbenito@texmacs.org
 ##               (C) 2019  Darcy Shen
+##               (C) 2021  Jeroen Wouters
 ##
 ## This software falls under the GNU general public license version 3 or later.
 ## It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -7,6 +7,7 @@
 #               (C) 2012       Adrian Soto
 #               (C) 2014       Miguel de Benito Delgado, mdbenito@texmacs.org
 #               (C) 2018-2020  Darcy Shen
+#               (C) 2021       Jeroen Wouters
 #
 # This software falls under the GNU general public license version 3 or later.
 # It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -15,19 +15,24 @@
 import os
 import sys
 import platform
-from os.path import exists
-tmpy_home_path = os.environ.get("TEXMACS_HOME_PATH") + "/plugins/tmpy"
-if (exists (tmpy_home_path)):
-    sys.path.append(os.environ.get("TEXMACS_HOME_PATH") + "/plugins/")
-else:
-    sys.path.append(os.environ.get("TEXMACS_PATH") + "/plugins/")
-
-
 
 import traceback
 import string
 import ast
 from inspect   import ismodule, getsource, getsourcefile
+
+from os.path import exists
+
+sys.path.append(os.path.join(os.getenv("TEXMACS_HOME_PATH").replace("\\", "/"),
+                "plugins"))
+sys.path.append(os.path.join(os.getenv("TEXMACS_PATH").replace("\\", "/"),
+                "plugins"))
+
+from contextlib import redirect_stdout
+import io
+
+import tmpy
+
 from tmpy.compat import py_ver
 from tmpy.capture import CaptureStdout
 from tmpy.postscript import ps_out, PSOutDummy, pdf_out, FileOutDummy
@@ -125,9 +130,10 @@ sys.stdout = os.fdopen (sys.stdout.fileno(), 'w')
 ###############################################################################
 # Session start
 ###############################################################################
-if (exists (tmpy_home_path)):
-    flush_verbatim ("WARNING: You are under develop mode using " + tmpy_home_path)
-    flush_newline (2)
+if os.path.commonpath([os.getenv("TEXMACS_HOME_PATH"),tmpy.__file__])  \
+            == os.getenv("TEXMACS_HOME_PATH"):
+    flush_verbatim ("WARNING: You are under develop mode using " + tmpy_path)
+    #flush_newline (2)
 flush_verbatim (f"Python { platform.python_version() } [{ sys.executable }] \n" +
                "Python plugin for TeXmacs.\n" +
                "Please see the documentation in Help -> Plugins -> Python")

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -146,7 +146,8 @@ sys.stdout = os.fdopen (sys.stdout.fileno(), 'w')
 ###############################################################################
 if os.path.commonpath([os.getenv("TEXMACS_HOME_PATH"),tmpy.__file__])  \
             == os.getenv("TEXMACS_HOME_PATH"):
-    flush_verbatim ("WARNING: You are under develop mode using " + tmpy_path)
+    flush_verbatim ("WARNING: development mode enabled, using " + \
+                os.path.dirname(tmpy.__file__))
     #flush_newline (2)
 flush_verbatim (f"Python { platform.python_version() } [{ sys.executable }] \n" +
                "Python plugin for TeXmacs.\n" +

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -122,7 +122,7 @@ def eval_code (code, p_globals):
     return ret, output
 
 __version__ = '3.0'
-__author__ = 'Ero Carrera, Adrian Soto, Miguel de Benito Delgado, Darcy Shen'
+__author__ = 'Ero Carrera, Adrian Soto, Miguel de Benito Delgado, Darcy Shen, Jeroen Wouters'
 my_globals   = {}
 
 # We insert into the session's namespace the 'ps_out' and 'pdf_out' methods.

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -104,7 +104,7 @@ def compile_help (text):
     return dict (map (lambda k_v: (k_v[0], as_scm_string (k_v[1])), out.items()))
 
 
-def my_eval (code, p_globals):
+def eval_code (code, p_globals):
     '''Execute a script and return the value of the last expression'''
 
     # capture stdout
@@ -177,5 +177,5 @@ while True:
                 continue
             lines.append (line)
         text = '\n'.join (lines[:-1])
-        ret, output= my_eval (text, my_globals)
+        ret, output= eval_code (text, my_globals)
         flush_output (output,ret)

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -47,18 +47,23 @@ if py_ver == 2:
 # import logging as log
 # log.basicConfig(filename='/tmp/tm_python.log',level=log.INFO)
 
-def flush_output (data):
+def flush_output (output,data):
     """Do some parsing on the output according to its type.
     
     Non printable characters in unicode strings are escaped
     and objects of type None are not printed (so that procedure calls,
     as opposed to function calls, don't produce any output)."""
-
+    
+    # wrap stdout output and data output in nested DATA_BEGIN/DATA_END blocks
+    data_begin()
+    os.sys.stdout.write("verbatim:")
+    
+    if output != "":
+        flush_verbatim(output)
+    
     if (data is None):
         flush_verbatim ("")
-        return
-
-    if isinstance (data, PSOutDummy):
+    elif isinstance (data, PSOutDummy):
         flush_ps (data.content)
     elif isinstance (data, FileOutDummy):
         if (data.content is None):
@@ -67,6 +72,8 @@ def flush_output (data):
             flush_file (data.content)
     else:
         flush_verbatim (str(data))
+    
+    data_end()
 
 def as_scm_string (text):
     return '"%s"' % text.replace('\\', '\\\\').replace('"', '\\"')
@@ -100,15 +107,17 @@ def compile_help (text):
 def my_eval (code, p_globals):
     '''Execute a script and return the value of the last expression'''
 
-    block = ast.parse(code, mode='exec')
+    # capture stdout
     f = io.StringIO()
     with redirect_stdout(f):
-        if len(block.body) > 1 and isinstance(block.body[-1], ast.Expr):
-            last = ast.Expression(block.body.pop().value)
-            exec(compile(block, '<string>', mode='exec'), p_globals)
-            ret = eval(compile(last, '<string>', mode='eval'), p_globals)
-        else:
-            ret = eval(code, p_globals)
+        # Is it an expression or a statement (e.g. an assignment "a=1"), in 
+        # which case `compile` in raises a SyntaxError  
+        # (https://stackoverflow.com/questions/3876231/python-how-to-tell-if-a-string-represent-a-statement-or-an-expression)
+        try:
+            code= compile(code, '<string>', 'eval')
+        except SyntaxError:
+            code= compile (code, '<string>', 'exec')
+        ret = eval(code, p_globals)
     output = f.getvalue()
     return ret, output
 
@@ -168,23 +177,5 @@ while True:
                 continue
             lines.append (line)
         text = '\n'.join (lines[:-1])
-        
-        # TODO move both expression and statement case to my_eval (rename to eval_capture)
-        # Is it an expression?
-        try:
-            ret, output= my_eval (text, my_globals)
-        # Is it a statement (e.g. an assignment "a=1"), in which case `compile`
-        # in my_eval raises a SyntaxError
-        # (https://stackoverflow.com/questions/3876231/python-how-to-tell-if-a-string-represent-a-statement-or-an-expression)
-        except SyntaxError:
-            ret, output= CaptureStdout.capture (text, my_globals, "tm_python")
-        
-        if ret is not None:
-            if output != "":
-                result = output + "\n" + str(ret)
-            else:
-                result = str(ret)
-        else:
-            result = output
-
-        flush_output (result)
+        ret, output= my_eval (text, my_globals)
+        flush_output (output,ret)

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -100,18 +100,22 @@ def my_eval (code, p_globals):
     '''Execute a script and return the value of the last expression'''
 
     block = ast.parse(code, mode='exec')
-    if len(block.body) > 1 and isinstance(block.body[-1], ast.Expr):
-        last = ast.Expression(block.body.pop().value)
-        exec(compile(block, '<string>', mode='exec'), p_globals)
-        return eval(compile(last, '<string>', mode='eval'), p_globals)
-    else:
-        return eval(code, p_globals)
+    f = io.StringIO()
+    with redirect_stdout(f):
+        if len(block.body) > 1 and isinstance(block.body[-1], ast.Expr):
+            last = ast.Expression(block.body.pop().value)
+            exec(compile(block, '<string>', mode='exec'), p_globals)
+            ret = eval(compile(last, '<string>', mode='eval'), p_globals)
+        else:
+            ret = eval(code, p_globals)
+    output = f.getvalue()
+    return ret, output
 
 __version__ = '3.0'
 __author__ = 'Ero Carrera, Adrian Soto, Miguel de Benito Delgado, Darcy Shen'
 my_globals   = {}
 
-# We insert into the session's namespace the 'ps_out' method.
+# We insert into the session's namespace the 'ps_out' and 'pdf_out' methods.
 my_globals['ps_out'] = ps_out
 my_globals['pdf_out'] = pdf_out
 

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -76,7 +76,7 @@ def compile_help (text):
     out = {"help" : "", "src": "", "file": ""}
 
     try:
-        out["help"] = CaptureStdout.capture (cmd, my_globals, "tm_python");
+        ret, out["help"] = CaptureStdout.capture (cmd, my_globals, "tm_python");
     except Exception as e:
         out ["help"] = 'No help for "%s": %s' % (text, e)
 

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -157,8 +157,23 @@ while True:
                 continue
             lines.append (line)
         text = '\n'.join (lines[:-1])
-        try: # Is it an expression?
-            result= my_eval (text, my_globals)
-        except:
-            result= CaptureStdout.capture (text, my_globals, "tm_python")
+        
+        # TODO move both expression and statement case to my_eval (rename to eval_capture)
+        # Is it an expression?
+        try:
+            ret, output= my_eval (text, my_globals)
+        # Is it a statement (e.g. an assignment "a=1"), in which case `compile`
+        # in my_eval raises a SyntaxError
+        # (https://stackoverflow.com/questions/3876231/python-how-to-tell-if-a-string-represent-a-statement-or-an-expression)
+        except SyntaxError:
+            ret, output= CaptureStdout.capture (text, my_globals, "tm_python")
+        
+        if ret is not None:
+            if output != "":
+                result = output + "\n" + str(ret)
+            else:
+                result = str(ret)
+        else:
+            result = output
+
         flush_output (result)

--- a/plugins/tmpy/session/tm_python.py
+++ b/plugins/tmpy/session/tm_python.py
@@ -60,7 +60,7 @@ def flush_output (data):
         else:
             flush_file (data.content)
     else:
-        flush_verbatim (str(data).strip())
+        flush_verbatim (str(data))
 
 def as_scm_string (text):
     return '"%s"' % text.replace('\\', '\\\\').replace('"', '\\"')


### PR DESCRIPTION
@darcy-shen 
This PR is meant to provide some extensions and simplification of the Python plugin. 

- The protocol is extended to include more formats.
- Output is now fully escaped, to prevent output hanging on for example `print("hello " + chr(2) + "there")`.
- The evaluation code and tmpy module import is simplified.