### PR TITLE
potential fix for python plugin when no python is installed

### DIFF
--- a/plugins/python/progs/init-python.scm
+++ b/plugins/python/progs/init-python.scm
@@ -32,17 +32,19 @@
       (string-append  s  "\n<EOF>\n"))))
 
 (define (python-utf8-command)
-  (if (python-command) (string-append (python-command) " -X utf8 ") #f))
+  (let ((pc (python-command)))
+    (if pc (string-append pc " -X utf8 ") #f)))
 
 (define (python-launcher)
-  (if (python-utf8-command)
-  (if (url-exists? "$TEXMACS_HOME_PATH/plugins/tmpy")
-      (string-append (python-utf8-command) " \""
+  (let ((puc (python-utf8-command)))
+    (if puc
+      (if (url-exists? "$TEXMACS_HOME_PATH/plugins/tmpy")
+        (string-append puc " \""
                      (getenv "TEXMACS_HOME_PATH")
                      "/plugins/tmpy/session/tm_python.py\"")
-      (string-append (python-utf8-command) " \""
+        (string-append puc " \""
                      (getenv "TEXMACS_PATH")
-                     "/plugins/tmpy/session/tm_python.py\""))))
+                     "/plugins/tmpy/session/tm_python.py\"")))))
 
 (plugin-configure python
   (:winpath "python*" ".")

--- a/plugins/python/progs/init-python.scm
+++ b/plugins/python/progs/init-python.scm
@@ -31,16 +31,18 @@
     (with s (texmacs->code (stree->tree u) "SourceCode")
       (string-append  s  "\n<EOF>\n"))))
 
-(define (python-utf8-command) (string-append (python-command) " -X utf8 "))
+(define (python-utf8-command)
+  (if (python-command) (string-append (python-command) " -X utf8 ") #f))
 
 (define (python-launcher)
+  (if (python-utf8-command)
   (if (url-exists? "$TEXMACS_HOME_PATH/plugins/tmpy")
       (string-append (python-utf8-command) " \""
                      (getenv "TEXMACS_HOME_PATH")
                      "/plugins/tmpy/session/tm_python.py\"")
       (string-append (python-utf8-command) " \""
                      (getenv "TEXMACS_PATH")
-                     "/plugins/tmpy/session/tm_python.py\"")))
+                     "/plugins/tmpy/session/tm_python.py\""))))
 
 (plugin-configure python
   (:winpath "python*" ".")


### PR DESCRIPTION
Python-launcher doesn't currently take into account the case where python isn't installed. Then `python-command` returns #f, which makes `string-append` fail.