### PR TITLE
fix fuile3 compile errors

### DIFF
--- a/TeXmacs/progs/kernel/boot/ahash-table.scm
+++ b/TeXmacs/progs/kernel/boot/ahash-table.scm
@@ -181,10 +181,7 @@
 
 (define-public-macro (define-collection name . l)
   `(begin
-     (when (not (defined? ',name))
-       (if (defined? 'tm-define)
-           (tm-define ,name (make-ahash-table))
-           (define-public ,name (make-ahash-table))))
+     (define-public ,name (make-ahash-table))
      (define-collection-decls ,name ,(list 'quasiquote l))))
 
 (define-public-macro (extend-collection name . l)

--- a/TeXmacs/progs/kernel/library/base.scm
+++ b/TeXmacs/progs/kernel/library/base.scm
@@ -240,9 +240,12 @@
 ;; Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (compose g f)
-  "Compose the functions @f and @g"
-  (lambda x (g (apply f x))))
+
+(cond-expand (guile-3)
+  (else
+    (define-public (compose g f)
+      "Compose the functions @f and @g"
+      (lambda x (g (apply f x))))))
 
 (define-public (non pred?)
   "Return the negation of @pred?."


### PR DESCRIPTION
fix two guile3 compilation errors:
1. make process `compose` cond-expand since it's incorporated by guile3
2. change definition of `define-collection` since expression context function definition is not allowed