### PR TITLE
Fix QTMPipeLink's usage of QProcess

### DIFF
--- a/src/Plugins/Qt/QTMPipeLink.cpp
+++ b/src/Plugins/Qt/QTMPipeLink.cpp
@@ -49,7 +49,7 @@ bool
 QTMPipeLink::launchCmd () {
   if (state () != QProcess::NotRunning) killProcess (1000);
   //FIXME: is UTF8 the right encoding here?
-  QProcess::start(utf8_to_qstring(cmd));
+  startCommand (utf8_to_qstring (cmd));
   bool r= waitForStarted ();
   if (r) {
     connect (this, SIGNAL(readyReadStandardOutput ()), SLOT(readErrOut ()));


### PR DESCRIPTION
Fix launching of commands.

In qt4.8 there was a QProcess::start(command_line) which would automatically split the command line into args and then exec that.

In qt5 that disappeared in favor of QProcess::splitCommand and then QProcess::start--and written in a way so you can't call QProcess::start with just one string.

In qt6 that changed to start(const QString &program, const QStringList &arguments = {}, QIODeviceBase::OpenMode mode = ReadWrite), which we called as start(command_line) which did the wrong thing.

Fix it so that it works on Qt6.