### PR TITLE
qt_ui_element: Fix filter

### DIFF
--- a/src/Plugins/Qt/qt_ui_element.cpp
+++ b/src/Plugins/Qt/qt_ui_element.cpp
@@ -1038,7 +1038,7 @@ qt_ui_element_rep::as_qwidget () {
 
       QTMLineEdit* lineEdit = new QTMLineEdit (0, "string", "1w");
       QObject::connect (lineEdit, SIGNAL (textChanged (const QString&)),
-                        choiceWidget->filter(), SLOT (filterRegularExpression (const QString&)));
+                        choiceWidget->filter(), SLOT (setFilterRegularExpression (const QString&)));
       lineEdit->setText (to_qstring (filter));
       lineEdit->setFocusPolicy (Qt::StrongFocus);
 


### PR DESCRIPTION
In Qt 4, there was a method `setFilterRegExp(const QString&)`.

Neither Qt 5 nor Qt 6 have `filterRegularExpression(const QString&)`, which we were using.

So substitute `filterRegularExpression(const QString&)` by `setFilterRegularExpression (const QString&)`.

This will make it work on Qt 6.