### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/configure
+++ b/configure
@@ -5989,7 +5989,8 @@ printf "%s\n" "$as_me: WARNING: Drop duplicate flag $LC_MERGE_FLAGS_flag" >&2;}
   CONFIG_HOST_VENDOR="$host_vendor"
   CONFIG_HOST_CPU="$host_cpu"
   CONFIG_USER="$USER"
-  CONFIG_DATE="`date`"
+  DATE_FMT="+%Y-%m-%dT%H:%M:%S"
+  CONFIG_DATE="`SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"; date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT"`"
   CONFIG_QTPIPES="no"
   type rsync && CONFIG_CP="rsync -a --exclude='.*'" || CONFIG_CP="cp -f -R -p"
   # tweak for XCode project

--- a/misc/m4/tm_platform.m4
+++ b/misc/m4/tm_platform.m4
@@ -30,7 +30,8 @@ AC_DEFUN([TM_PLATFORM],[
   CONFIG_HOST_VENDOR="$host_vendor"
   CONFIG_HOST_CPU="$host_cpu"
   CONFIG_USER="$USER"
-  CONFIG_DATE="`date`"
+  DATE_FMT="+%Y-%m-%dT%H:%M:%S"
+  CONFIG_DATE="`SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"; date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT"`"
   CONFIG_QTPIPES="no"
   type rsync && CONFIG_CP="rsync -a --exclude='.*'" || CONFIG_CP="cp -f -R -p"
   # tweak for XCode project


### PR DESCRIPTION
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.
This date call works with different variants of date (GNU, BSD, other).

Also use UTC to be independent of timezone.
Also use ISO 8601 date format to be understood everywhere.

Note: I only tested the `configure` change, not the .m4 change. Can you test that part?

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.