### PR TITLE
[SVN] fix bashisms related to echo

### DIFF
--- a/plugins/feynmf/bin/tm_feynmf
+++ b/plugins/feynmf/bin/tm_feynmf
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #==============================================================================
 # MODULE     : tm_feynmf
 # VERSION    : 1.0
@@ -79,7 +79,7 @@ while [ 1 ]; do
 	    # Unitlength choosen such that size specification (1,1)
 	    # produces okayish output
 	    # - the linestyles in file feynmf-styles must be tuned to this!
-	    echo -E "\unitlength=20mm"            >> $TEMP_FILE.tex
+	    echo -E "\unitlength=20mm"           >> $TEMP_FILE.tex
 	    echo -E "\begin{document}"           >> $TEMP_FILE.tex
 	    echo -E "\begin{fmffile}{fmftempl}"  >> $TEMP_FILE.tex
 

--- a/plugins/lisp/bin/tm_lisp
+++ b/plugins/lisp/bin/tm_lisp
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export TEXMACS_LISP_PATH=$TEXMACS_PATH/plugins/lisp
 cd $TEXMACS_LISP_PATH

--- a/plugins/lush/bin/tm_lush
+++ b/plugins/lush/bin/tm_lush
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd $TEXMACS_PATH/plugins/lush
 echo -ne "\002verbatim:"
 cat << EOF

--- a/plugins/mathematica/bin/tm_mathematica
+++ b/plugins/mathematica/bin/tm_mathematica
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 error() {
     #echo -e "\002latex:\\red $1\005"


### PR DESCRIPTION
Description: upstream: fix: bashisms
 This patch fixes bashisms related to the use of `echo`
 in sh[ell] scripts: the builtin echo may not support
 the options `-e` and `-E`. For instance, dash(1) which
 is the default /bin/sh in Debian does not support these
 options for its builtin echo. bash(1) does. This patch
 simply forces the use of bash as shell interpreter
 where applicable.
Origin: debian
Author: Jerome Benoit <calculus _at_ debian _dot_ org >
Last-Update: 2024-08-08