### PR TITLE
[SVN] fix technical typo in xypic pyton plugin

### DIFF
--- a/plugins/tmpy/graph/xypic.py
+++ b/plugins/tmpy/graph/xypic.py
@@ -29,7 +29,7 @@ class XYpic(LaTeX):
 \\usepackage{amssymb}
 \\begin{document}
 """
-        self.post_code = "\end{document}"
+        self.post_code = "\\end{document}"
         self.message = "TeXmacs interface to XYpic (high level 2-dimensional graphics)"
 
     def evaluate(self, code):


### PR DESCRIPTION
Description: fix: typo: python script: xypic
 This patch fixes an escape typo in the python plugin dedicated to XYpic.
Origin: debian
Author: Jerome Benoit < calculus _at_ debian _dot_ org >
Last-Update: 2024-08-08