### PR TITLE
[SVN] update visible copyright year-tuples

### DIFF
--- a/TeXmacs/doc/about/about-summary.de.tm
+++ b/TeXmacs/doc/about/about-summary.de.tm
@@ -9,7 +9,7 @@
   <TeXmacs>>|<cell|>>|<row|<cell|Installierte
   Version>|<cell|<TeXmacs-version>>>|<row|<cell|Unterstützte
   Systeme>|<cell|Most GNU/<name|Linux> systems>>|<row|<cell|Copyright>|<cell|<copyright>
-  1998--2002 by Joris van der Hoeven >>|<row|<cell|Lizenz>|<cell|<hlink|GNU
+  1998\U2024 by Joris van der Hoeven >>|<row|<cell|Lizenz>|<cell|<hlink|GNU
   General Public License|$TEXMACS_PATH/LICENSE>>>|<row|<cell|Webseiten>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<verbatim|https://www.texmacs.org>>>|<row|<cell|<verbatim|http://www.gnu.org/software/texmacs>>>>>>>>|<row|<cell|Kontakt>|<cell|<verbatim|contact@texmacs.org>>>|<row|<cell|Postansschrift>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<abbr|Dr.>
   Joris van der Hoeven>>|<row|<cell|<abbr|Dépt.> de Mathématiques
   (<abbr|Bât.> 425)>>|<row|<cell|Université Paris-Sud>>|<row|<cell|91405

--- a/TeXmacs/doc/about/about-summary.en.tm
+++ b/TeXmacs/doc/about/about-summary.en.tm
@@ -10,7 +10,7 @@
   version>|<cell|<TeXmacs-version>>>|<row|<cell|SVN
   revision>|<cell|<TeXmacs-version-release|revision>>>|<row|<cell|Supported
   systems>|<cell|Most GNU/<name|Linux> systems>>|<row|<cell|Copyright>|<cell|<copyright>
-  1998\U2021 by Joris van der Hoeven >>|<row|<cell|License>|<cell|<hlink|GNU
+  1998\U2024 by Joris van der Hoeven >>|<row|<cell|License>|<cell|<hlink|GNU
   General Public License|$TEXMACS_PATH/LICENSE>>>|<row|<cell|Web
   sites>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<verbatim|https://www.texmacs.org>>>|<row|<cell|<verbatim|http://www.gnu.org/software/texmacs>>>>>>>>|<row|<cell|Contact>|<cell|<verbatim|contact@texmacs.org>>>|<row|<cell|Regular
   mail>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<abbr|Prof.>

--- a/TeXmacs/doc/about/about-summary.es.tm
+++ b/TeXmacs/doc/about/about-summary.es.tm
@@ -8,7 +8,7 @@
   <big-table|<descriptive-table|<tformat|<cwith|1|1|1|1|cell-row-span|1>|<cwith|1|1|1|1|cell-col-span|2>|<cwith|1|1|1|1|cell-halign|c>|<table|<row|<cell|GNU
   <TeXmacs>>|<cell|>>|<row|<cell|Versión>|<cell|<TeXmacs-version>>>|<row|<cell|Sistemas
   soportados>|<cell|La mayoría de los sistemas
-  GNU/<name|Linux>>>|<row|<cell|Copyright>|<cell|<copyright> 1998--2002 por
+  GNU/<name|Linux>>>|<row|<cell|Copyright>|<cell|<copyright> 1998--2024 por
   Joris van der Hoeven >>|<row|<cell|Licencia>|<cell|<hlink|Licencia Pública
   General GNU|$TEXMACS_PATH/LICENSE>>>|<row|<cell|Sitios
   web>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<verbatim|https://www.texmacs.org>>>|<row|<cell|<verbatim|http://www.gnu.org/software/texmacs>>>>>>>>|<row|<cell|Contacto>|<cell|<verbatim|contact@texmacs.org>>>|<row|<cell|Correo

--- a/TeXmacs/doc/about/about-summary.fr.tm
+++ b/TeXmacs/doc/about/about-summary.fr.tm
@@ -8,7 +8,7 @@
   <big-table|<descriptive-table|<tformat|<cwith|1|1|1|1|cell-row-span|1>|<cwith|1|1|1|1|cell-col-span|2>|<cwith|1|1|1|1|cell-halign|c>|<table|<row|<cell|GNU
   <TeXmacs>>|<cell|>>|<row|<cell|Version installée>|<cell|<TeXmacs-version>>>|<row|<cell|Systèmes
   reconnus>|<cell|la plupart des systèmes
-  GNU/<name|Linux>>>|<row|<cell|Droits d'auteur>|<cell|<copyright> 1998--2003
+  GNU/<name|Linux>>>|<row|<cell|Droits d'auteur>|<cell|<copyright> 1998--2024
   de Joris van der Hoeven >>|<row|<cell|Licence>|<cell|<hlink|GNU General
   Public License|$TEXMACS_PATH/LICENSE>>>|<row|<cell|Sites
   web>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<verbatim|https://www.texmacs.org>>>|<row|<cell|<verbatim|http://www.gnu.org/software/texmacs>>>>>>>>|<row|<cell|Contact>|<cell|<verbatim|contact@texmacs.org>>>|<row|<cell|Adresse

--- a/TeXmacs/doc/about/about-summary.it.tm
+++ b/TeXmacs/doc/about/about-summary.it.tm
@@ -8,7 +8,7 @@
   <big-table|<descriptive-table|<tformat|<cwith|1|1|1|1|cell-row-span|1>|<cwith|1|1|1|1|cell-col-span|2>|<cwith|1|1|1|1|cell-halign|c>|<table|<row|<cell|GNU
   <TeXmacs>>|<cell|>>|<row|<cell|<localize|Version>>|<cell|<TeXmacs-version>>>|<row|<cell|Sistemi
   supportati>|<cell|Principalmente sistemi
-  GNU/<name|Linux>>>|<row|<cell|Copyright>|<cell|<copyright> 1998--2002 by
+  GNU/<name|Linux>>>|<row|<cell|Copyright>|<cell|<copyright> 1998\U2024 by
   Joris van der Hoeven >>|<row|<cell|Licenza>|<cell|<hlink|GNU General Public
   License|$TEXMACS_PATH/LICENSE>>>|<row|<cell|Siti
   web>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<verbatim|https://www.texmacs.org>>>|<row|<cell|<verbatim|http://www.gnu.org/software/texmacs>>>>>>>>|<row|<cell|Contatti>|<cell|<verbatim|contact@texmacs.org>>>|<row|<cell|Indirizzi>|<cell|<tabular|<tformat|<twith|table-valign|T>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<table|<row|<cell|<abbr|Dr.>

--- a/src/Edit/editor.hpp
+++ b/src/Edit/editor.hpp
@@ -29,7 +29,7 @@
 #  include "../Style/Memorizer/memorizer.hpp"
 #endif
 #include "new_data.hpp"
-#define TEXMACS_COPYRIGHT (string("(c) 1999-2020 by Joris van der Hoeven and others"))
+#define TEXMACS_COPYRIGHT (string("(c) 1999-2024 by Joris van der Hoeven and others"))
 
 #define THE_CURSOR 1
 #define THE_FOCUS 2


### PR DESCRIPTION
Description: upstream: update: visible copyright year-tuples
 Update copyright year-tuples that are visible to end-users.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _at_ debian _dot_ org >
Last-Update: 2024-08-08