### PR TITLE
refresh m4 script m/m/imlib2.m4

### DIFF
--- a/misc/m4/imlib2.m4
+++ b/misc/m4/imlib2.m4
@@ -22,8 +22,8 @@ AC_DEFUN([LC_IMLIB2],[
   if test "$with_imlib2" = "no" -o "$with_imlib2" = "" ; then
       AC_MSG_RESULT([disabling imlib2 support])
   else
-      CPPFLAGS=`imlib2-config --cflags`
-      LIBS=`imlib2-config --libs`
+      CPPFLAGS=`pkg-config --cflags imlib2`
+      LIBS=`pkg-config --libs imlib2`
       AC_CHECK_HEADER(Imlib2.h,
       AC_MSG_CHECKING(for imlib2)
       AC_LINK_IFELSE([AC_LANG_PROGRAM([[


### PR DESCRIPTION
Description: upstream: refresh: autotools: m/m/imlib2.m4
 Use the pkg-config(1) machinery instead of the helper `imlib2-config`
 to set the built parameters related to the imlib2 library.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _at_ debian _dot_ org >
Last-Update: 2024-08-08