### PR TITLE
harden plugins install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -63,10 +63,10 @@ TEXMACS: EMPTY_DIRS @MKGUILE@
 	$(CP) misc/scripts/fig2ps $(tmdir)/bin
 	$(CP) misc/scripts/texmacs $(tmdir)/bin
 	$(CP) misc/scripts/tm_gs $(tmdir)/bin
-	$(CHMOD) 755 $(tmdir)/bin/*
-	$(CHMOD) 755 plugins/*/bin/*
 	$(RM) -r $(tmdir)/plugins
 	$(CP) plugins $(tmdir)/
+	$(CHMOD) 755 $(tmdir)/bin/*
+	$(CHMOD) 755 $(tmdir)/plugins/*/bin/*
 	@echo ----------------------------------------------------
 	@echo dynamic TeXmacs has been successfully compiled
 
@@ -80,10 +80,10 @@ STATIC_TEXMACS: EMPTY_DIRS
 	$(CP) misc/scripts/fig2ps $(tmdir)/bin
 	$(CP) misc/scripts/texmacs $(tmdir)/bin
 	$(CP) misc/scripts/tm_gs $(tmdir)/bin
-	$(CHMOD) 755 $(tmdir)/bin/*
-	$(CHMOD) 755 plugins/*/bin/*
 	$(RM) -r $(tmdir)/plugins
 	$(CP) plugins $(tmdir)/plugins
+	$(CHMOD) 755 $(tmdir)/bin/*
+	$(CHMOD) 755 $(tmdir)/plugins/*/bin/*
 	@echo ----------------------------------------------------
 	@echo static TeXmacs has been successfully compiled
 


### PR DESCRIPTION
Description: upstream: harden: install: plugins
 The current maneuver around the installation of the plugins folder
 is confusing for the debhelper(1) suite tools. It might be also confusing
 for other distribution suite tools. What is confusing is that the permission
 of the source material is changed. This change leads to misinterpretation.
 This patch reproduces the desired end-result of the maneuver but it avoids
 to touch any source material.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2024-08-08