### PR TITLE
[SVN] reformat NAME entry in texmacs manpage

### DIFF
--- a/misc/man/texmacs.1.in
+++ b/misc/man/texmacs.1.in
@@ -1,6 +1,6 @@
 .TH texmacs 1 "12Sep2005" @PACKAGE@-@DEVEL_VERSION@
 .SH NAME
-GNU TeXmacs - a WYSIWYG mathematical text editor
+texmacs - GNU project TeXmacs WYSIWYG scientific text editor
 .PP
 .SH SYNOPSIS
 texmacs [\fIOPTION\fR]... [\fISOURCE\fR]...
@@ -8,7 +8,7 @@ texmacs [\fIOPTION\fR]... [\fISOURCE\fR]...
 .SH INTRODUCTION
 GNU TeXmacs is a free scientific text editor, which was both inspired
 by TeX and GNU Emacs. The editor allows you to write structured documents
-via a wysiwyg (what-you-see-is-what-you-get) and user friendly interface.
+via a WYSIWYG (what-you-see-is-what-you-get) and user friendly interface.
 New styles may be created by the user. The program implements high-quality
 typesetting algorithms and TeX fonts, which help you to produce
 professionally looking documents.


### PR DESCRIPTION
Description: upstream: harden: manpage: texmacs
 This patch essentially reformats the **NAME** entry of the texmacs manpage.
 This entry now mimics the **NAME** entry in the emacs(1) manpage.
 But, most importantly, it silences lintian(1).
Origin: vendor, Debian
Author: Jerome Benoit < calculus _at_ debian _dot_ org >
Last-Update: 2024-08-08