### PR TITLE
reproducible build: see SOURCE_DATE_EPOCH

### DIFF
--- a/misc/m4/tm_platform.m4
+++ b/misc/m4/tm_platform.m4
@@ -30,11 +30,16 @@ AC_DEFUN([TM_PLATFORM],[
   CONFIG_HOST_VENDOR="$host_vendor"
   CONFIG_HOST_CPU="$host_cpu"
   CONFIG_USER="$USER"
-  CONFIG_DATE="`date`"
+  CONFIG_DATE_FMT="+%Y%m%dT%H%M%SZ"
+  CONFIG_DATE="`date -u $CONFIG_DATE_FMT`"
   CONFIG_QTPIPES="no"
   type rsync && CONFIG_CP="rsync -a --exclude='.*'" || CONFIG_CP="cp -f -R -p"
   # tweak for XCode project
   CONFIG_ARCHS='$(NATIVE_ARCH)'
+
+  if [[[ "x$SOURCE_DATE_EPOCH" != "x" ]]]
+  then CONFIG_DATE=`date -u -d "@$SOURCE_DATE_EPOCH $CONFIG_DATE_FMT" 2>/dev/null`
+  fi
 
   X11_CFLAGS="$X_CFLAGS"
   X11_LDFLAGS="$X_LIBS -lXext -lX11"

--- a/src/Texmacs/Server/tm_debug.cpp
+++ b/src/Texmacs/Server/tm_debug.cpp
@@ -38,7 +38,7 @@ get_system_information () {
   r << "  Processor        : "
     << HOST_CPU << "\n";
   r << "  Crash date       : "
-    << var_eval_system ("date") << "\n";
+    << var_eval_system ("date -u +%Y%m%dT%H%M%SZ") << "\n";
   return r;
 }
 


### PR DESCRIPTION
Description: upstream: reproducible: SOURCE_DATE_EPOCH
 This patch essentially takes into account SOURCE_DATE_EPOCH
 when setting CONFIG_DATE. It also takes the opportunity to format dates
 with a universal, unique and concise time-format that follows
 the ISO 8601 standard. This patch echoes the pull-request #77 .
Origin: vendor, Debian
Author: Jerome Benoit < calculus _at_  debian _dot_ org >
Last-Update: 2024-08-08