### PR TITLE
reproducible build: CONFIG_USER

### DIFF
--- a/misc/m4/tm_platform.m4
+++ b/misc/m4/tm_platform.m4
@@ -36,6 +36,10 @@ AC_DEFUN([TM_PLATFORM],[
   # tweak for XCode project
   CONFIG_ARCHS='$(NATIVE_ARCH)'
 
+  if [[[ "x$CONFIG_USER" == "x" ]]]
+  then CONFIG_USER=`lsb_release -is 2> /dev/null` || CONFIG_USER=`dpkg-vendor --query vendor` || CONFIG_USER="UNKNOWN"
+	fi
+
   X11_CFLAGS="$X_CFLAGS"
   X11_LDFLAGS="$X_LIBS -lXext -lX11"
 


### PR DESCRIPTION
Description: upstream: reproducible: CONFIG_USER
 This patch sets a default CONFIG_USER when USER is not assigned.
 In environment set up to build reproducibly, the USER environment variable
 may not be set up. In this case CONFIG_USER is currently empty.
 So is BUILD_USER (see `src/System/tm_configure.in`). This can be confusing
 as BUILD_USER is used to report bugs (see `src/Texmacs/Server/tm_debug.cpp`).
 This patch set up as default CONFIG_USER the distributor's ID
 (lsb_release(1)), the vendor name, or "UNKNOWN". The set-up uses a Debian
 specific tool (dpkg-vendor(1)) as second choice if necessary. But this set-up
 is set up as a `||` chain so that other distribution dpkg-vendor-alike-tools
 can be inserted.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _at_ debian _dot_org >
Last-Update: 2024-08-08