### PR TITLE
[SVN] maple plugin: enhancement

### DIFF
--- a/plugins/maple/Makefile.9
+++ b/plugins/maple/Makefile.9
@@ -13,7 +13,9 @@ CC = gcc
 TEXMACS_HOME_PATH ?= $(HOME)/.TeXmacs
 TEXMACS_MAPLE_BIN ?= $(shell which maple)
 TEXMACS_MAPLE_DIR ?= $(shell echo 'printf(kernelopts(mapledir));' | $(TEXMACS_MAPLE_BIN) -q)
-MAPLE_SYS_BIN     ?= $(shell echo "printf(kernelopts(bindir));" | $(TEXMACS_MAPLE_BIN) -q)
+MAPLE_SYS_BIN     ?= $(shell echo 'printf(kernelopts(bindir));' | $(TEXMACS_MAPLE_BIN) -q)
+
+TEXMACS_MAPLE_STAMP ?= $(TEXMACS_MAPLE_DIR)/license/version.txt
 
 MAPLE_CPPFLAGS ?= -I$(TEXMACS_MAPLE_DIR)/extern/include
 MAPLE_LDFLAGS  ?= -L$(MAPLE_SYS_BIN) -Wl,-rpath,$(MAPLE_SYS_BIN)
@@ -27,7 +29,7 @@ $(TEXMACS_HOME_PATH)/bin/tm_maple_9.sh: $(TEXMACS_MAPLE_DIR)/bin/maple
 			-e 's%$${MAPLE}/$$MAPLE_SYS_BIN/maplew%$(TEXMACS_HOME_PATH)/bin/tm_maple_9%' \
 		$< > $@ && chmod a+x $@
 
-$(TEXMACS_HOME_PATH)/bin/tm_maple_9: src.9/tm_maple_9.c
+$(TEXMACS_HOME_PATH)/bin/tm_maple_9: src.9/tm_maple_9.c $(TEXMACS_MAPLE_STAMP)
 	$(CC) $(MAPLE_LDFLAGS) $(MAPLE_CPPFLAGS) $< -o $@ $(MAPLE_LIBADD)
 
 clean:

--- a/plugins/maple/Makefile.9
+++ b/plugins/maple/Makefile.9
@@ -1,7 +1,7 @@
 
 ###############################################################################
 # MODULE     : Make file for maple plugin
-# COPYRIGHT  : (C) 1999-2008  Joris van der Hoeven
+# COPYRIGHT  : (C) 1999-2024  Joris van der Hoeven
 ###############################################################################
 # This software falls under the GNU general public license version 3 or later.
 # It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
@@ -10,17 +10,25 @@
 
 CC = gcc
 
-#TEXMACS_HOME_PATH = $(HOME)/.TeXmacs
-#TEXMACS_MAPLE_DIR = $(shell realpath `which maple` | sed -e 's%/bin/maple$$%%')
+TEXMACS_HOME_PATH ?= $(HOME)/.TeXmacs
+TEXMACS_MAPLE_BIN ?= $(shell which maple)
+TEXMACS_MAPLE_DIR ?= $(shell echo 'printf(kernelopts(mapledir));' | $(TEXMACS_MAPLE_BIN) -q)
+MAPLE_SYS_BIN     ?= $(shell echo "printf(kernelopts(bindir));" | $(TEXMACS_MAPLE_BIN) -q)
 
-#MAPLE_CPPFLAGS = -I$(TEXMACS_MAPLE_DIR)/extern/include
-#MAPLE_LDFLAGS = -L$(TEXMACS_MAPLE_DIR)/bin.IBM_INTEL_LINUX -Wl,-rpath,$(TEXMACS_MAPLE_DIR)/bin.IBM_INTEL_LINUX -lmaplec
+MAPLE_CPPFLAGS ?= -I$(TEXMACS_MAPLE_DIR)/extern/include
+MAPLE_LDFLAGS  ?= -L$(MAPLE_SYS_BIN) -Wl,-rpath,$(MAPLE_SYS_BIN)
+MAPLE_LIBADD   ?= -lmaplec
 
 all: $(TEXMACS_HOME_PATH)/bin/tm_maple_9.sh $(TEXMACS_HOME_PATH)/bin/tm_maple_9
 
 $(TEXMACS_HOME_PATH)/bin/tm_maple_9.sh: $(TEXMACS_MAPLE_DIR)/bin/maple
-	cat $(TEXMACS_MAPLE_DIR)/bin/maple | sed 's%$${MAPLE}/$$MAPLE_SYS_BIN/cmaple%$${HOME}/.TeXmacs/bin/tm_maple_9%' | sed 's%$${MAPLE}/$$MAPLE_SYS_BIN/maplew%$${HOME}/.TeXmacs/bin/tm_maple_9%' > $(TEXMACS_HOME_PATH)/bin/tm_maple_9.sh
-	chmod a+x $(TEXMACS_HOME_PATH)/bin/tm_maple_9.sh
+	sed \
+			-e 's%$${MAPLE}/$$MAPLE_SYS_BIN/cmaple%$(TEXMACS_HOME_PATH)/bin/tm_maple_9%' \
+			-e 's%$${MAPLE}/$$MAPLE_SYS_BIN/maplew%$(TEXMACS_HOME_PATH)/bin/tm_maple_9%' \
+		$< > $@ && chmod a+x $@
 
 $(TEXMACS_HOME_PATH)/bin/tm_maple_9: src.9/tm_maple_9.c
-	$(CC) $(MAPLE_LDFLAGS) $(MAPLE_CPPFLAGS) src.9/tm_maple_9.c -o $(TEXMACS_HOME_PATH)/bin/tm_maple_9
+	$(CC) $(MAPLE_LDFLAGS) $(MAPLE_CPPFLAGS) $< -o $@ $(MAPLE_LIBADD)
+
+clean:
+	rm -f $(TEXMACS_HOME_PATH)/bin/tm_maple_9 $(TEXMACS_HOME_PATH)/bin/tm_maple_9.sh

--- a/plugins/maple/bin/tm_maple
+++ b/plugins/maple/bin/tm_maple
@@ -1,32 +1,58 @@
 #!/bin/sh
 ##set -x
 
+TEXMACS_HOME_PLUGINS_MAPLE_DIR="$TEXMACS_HOME_PATH/plugins/maple"
+if [ ! -d $TEXMACS_HOME_PLUGINS_MAPLE_DIR ]; then
+	mkdir $TEXMACS_HOME_PLUGINS_MAPLE_DIR
+fi
+TEXMACS_HOME_PLUGINS_MAPLE_CONF="$TEXMACS_HOME_PLUGINS_MAPLE_DIR/tm_maple.conf"
+
 TEXMACS_MAPLE_BIN=`which maple`
+TEXMACS_HOME_PLUGINS_MAPLE_DO_SYMLINK="no"
+if [ -r $TEXMACS_HOME_PLUGINS_MAPLE_CONF ]; then
+	. $TEXMACS_HOME_PLUGINS_MAPLE_CONF
+fi
 
 TEXMACS_MAPLE_DIR=`echo "printf(kernelopts(mapledir));" | $TEXMACS_MAPLE_BIN -q`
 export TEXMACS_MAPLE_BIN
 export TEXMACS_MAPLE_DIR
 
 if [ -d "$TEXMACS_MAPLE_DIR/extern" ]; then
-	if [ ! -x "$TEXMACS_HOME_PATH/bin/tm_maple_9" -o ! -x "$TEXMACS_HOME_PATH/bin/tm_maple_9.sh" ]; then
+	TEXMACS_MAPLE_STAMP="$TEXMACS_MAPLE_DIR/license/version.txt"
+	if [ ! -f $TEXMACS_MAPLE_STAMP ]; then
+		TEXMACS_MAPLE_STAMP="$TEXMACS_MAPLE_DIR/license/license.dat"
+		if [ ! -f $TEXMACS_MAPLE_STAMP ]; then
+			TEXMACS_MAPLE_STAMP="$TEXMACS_HOME_PLUGINS_MAPLE_DIR/maple-stamp"
+			MAPLE_KERNEL_BUILD_DATE=`echo "printf(op(3,sscanf(kernelopts(version),\"%[^,],%[^,],%[^,]\")));" | $TEXMACS_MAPLE_BIN -q`
+			touch -d "$MAPLE_KERNEL_BUILD_DATE" $TEXMACS_MAPLE_STAMP
+		fi
+	fi
+	if [ ! -x "$TEXMACS_HOME_PATH/bin/tm_maple_9" -o "$TEXMACS_MAPLE_STAMP" -nt "$TEXMACS_HOME_PATH/bin/tm_maple_9" ] || \
+			[ ! -x "$TEXMACS_HOME_PATH/bin/tm_maple_9.sh" -o "$TEXMACS_MAPLE_STAMP" -nt "$TEXMACS_HOME_PATH/bin/tm_maple_9.sh" ]; then
 		MAPLE_SYS_BIN=`echo "printf(kernelopts(bindir));" | $TEXMACS_MAPLE_BIN -q`
+		MAPLE_LIBRARY_PATH=$MAPLE_SYS_BIN
+		if [ -d "$MAPLE_SYS_BIN/system" -a -x "$MAPLE_SYS_BIN/cppcheck" ]; then
+			if ! ( LD_LIBRARY_PATH=$MAPLE_SYS_BIN $MAPLE_SYS_BIN/cppcheck > /dev/null 2>&1 ; ) then
+				MAPLE_LIBRARY_PATH="$MAPLE_SYS_BIN/system:$MAPLE_LIBRARY_PATH"
+			fi
+		fi
 		MAPLE_CPPFLAGS="-I$TEXMACS_MAPLE_DIR/extern/include"
-		MAPLE_LDFLAGS="-L$MAPLE_SYS_BIN"
+		MAPLE_LDFLAGS="-L$MAPLE_LIBRARY_PATH"
 		MAPLE_LIBADD="-lmaplec"
 		case "${MAPLE_SYS_BIN##*bin.}" in
 			IBM_INTEL_LINUX|X86_64_LINUX)
-				MAPLE_LDFLAGS="$MAPLE_LDFLAGS -Wl,-rpath,$MAPLE_SYS_BIN" ;;
+				MAPLE_LDFLAGS="$MAPLE_LDFLAGS -Wl,-rpath,$MAPLE_LIBRARY_PATH" ;;
 			*) ;;
 		esac
 		export MAPLE_CPPFLAGS
 		export MAPLE_LDFLAGS
 		export MAPLE_LIBADD
-		make -s -C $TEXMACS_PATH/plugins/maple -f Makefile.9 TEXMACS_HOME_PATH="$TEXMACS_HOME_PATH"
+		make -s -C $TEXMACS_PATH/plugins/maple -f Makefile.9 TEXMACS_HOME_PATH="$TEXMACS_HOME_PATH" TEXMACS_MAPLE_STAMP="$TEXMACS_MAPLE_STAMP"
 		if [ $? -ne 0 ]; then
 			echo "cannot build $TEXMACS_HOME_PATH/bin/tm_maple_9*" 1>&2
 			exit 1
 		fi
-		if [ ! -f $TEXMACS_HOME_PATH/bin/tm_maple ]; then
+		if [ "$TEXMACS_HOME_PLUGINS_MAPLE_DO_SYMLINK" != "no" -a ! -f $TEXMACS_HOME_PATH/bin/tm_maple ]; then
 			{ cd $TEXMACS_HOME_PATH/bin && ln -s tm_maple_9.sh tm_maple ; }
 		fi
 	fi

--- a/plugins/maple/bin/tm_maple
+++ b/plugins/maple/bin/tm_maple
@@ -1,43 +1,39 @@
 #!/bin/sh
+##set -x
 
 TEXMACS_MAPLE_BIN=`which maple`
-TEXMACS_MAPLE_BIN=`realpath "$TEXMACS_MAPLE_BIN"`
-#if [ $? -ne 0 ]
-#then
-#    TEXMACS_MAPLE_BIN=`which maple`
-#    TEXMACS_MAPLE_BIN=`realpath.py "$TEXMACS_MAPLE_BIN"`
-#fi
-if [ $? -ne 0 ]
-then
-    TEXMACS_MAPLE_BIN=`which maple`
-fi
-#TEXMACS_MAPLE_DIR=`echo -n "$TEXMACS_MAPLE_BIN" | sed -e 's%/bin/maple$%%'`
-TEXMACS_MAPLE_DIR=`echo "$TEXMACS_MAPLE_BIN" | sed -e 's%/bin/maple$%%'`
+
+TEXMACS_MAPLE_DIR=`echo "printf(kernelopts(mapledir));" | $TEXMACS_MAPLE_BIN -q`
 export TEXMACS_MAPLE_BIN
 export TEXMACS_MAPLE_DIR
 
-MAPLE_CPPFLAGS="-I$TEXMACS_MAPLE_DIR/extern/include"
-MAPLE_SYS_BIN=""
-if test -e "$TEXMACS_MAPLE_DIR/bin/maple.system.type"; then
-  MAPLE_SYS_BIN=$("$TEXMACS_MAPLE_DIR/bin/maple.system.type")
+if [ -d "$TEXMACS_MAPLE_DIR/extern" ]; then
+	if [ ! -x "$TEXMACS_HOME_PATH/bin/tm_maple_9" -o ! -x "$TEXMACS_HOME_PATH/bin/tm_maple_9.sh" ]; then
+		MAPLE_SYS_BIN=`echo "printf(kernelopts(bindir));" | $TEXMACS_MAPLE_BIN -q`
+		MAPLE_CPPFLAGS="-I$TEXMACS_MAPLE_DIR/extern/include"
+		MAPLE_LDFLAGS="-L$MAPLE_SYS_BIN"
+		MAPLE_LIBADD="-lmaplec"
+		case "${MAPLE_SYS_BIN##*bin.}" in
+			IBM_INTEL_LINUX|X86_64_LINUX)
+				MAPLE_LDFLAGS="$MAPLE_LDFLAGS -Wl,-rpath,$MAPLE_SYS_BIN" ;;
+			*) ;;
+		esac
+		export MAPLE_CPPFLAGS
+		export MAPLE_LDFLAGS
+		export MAPLE_LIBADD
+		make -s -C $TEXMACS_PATH/plugins/maple -f Makefile.9 TEXMACS_HOME_PATH="$TEXMACS_HOME_PATH"
+		if [ $? -ne 0 ]; then
+			echo "cannot build $TEXMACS_HOME_PATH/bin/tm_maple_9*" 1>&2
+			exit 1
+		fi
+		if [ ! -f $TEXMACS_HOME_PATH/bin/tm_maple ]; then
+			{ cd $TEXMACS_HOME_PATH/bin && ln -s tm_maple_9.sh tm_maple ; }
+		fi
+	fi
+	exec "$TEXMACS_HOME_PATH/bin/tm_maple_9.sh"
+elif [ -f "$TEXMACS_MAPLE_DIR/mwshelp" ]; then
+	exec tm_maple_5
+else
+	echo "Maple version not yet supported" 1>&2
 fi
-MAPLE_LDFLAGS="-L$TEXMACS_MAPLE_DIR/$MAPLE_SYS_BIN -lmaplec"
-if [ "$MAPLE_SYS_BIN" -eq "bin.IBM_INTEL_LINUX" ]; then
-  MAPLE_LDFLAGS="-L$TEXMACS_MAPLE_DIR/$MAPLE_SYS_BIN -Wl,-rpath,$(TEXMACS_MAPLE_DIR)/$MAPLE_SYS_BIN -lmaplec"
-fi
-export MAPLE_CPPFLAGS
-export MAPLE_LDFLAGS
-
-if [ -d "$TEXMACS_MAPLE_DIR/extern" ]
-then
-    if [ -f "$TEXMACS_HOME_PATH/bin/tm_maple_9.sh" ]
-    then
-        DUMMY="dummy"
-    else
-        cd $TEXMACS_PATH/plugins/maple; make -f Makefile.9 TEXMACS_HOME_PATH="$TEXMACS_HOME_PATH"
-    fi
-    exec "${HOME}/.TeXmacs/bin/tm_maple_9.sh"
-elif [ -f "$TEXMACS_MAPLE_DIR/mwshelp" ]
-then
-    exec tm_maple_5
-fi
+exit 126

--- a/plugins/maple/src.9/tm_maple_9.c
+++ b/plugins/maple/src.9/tm_maple_9.c
@@ -16,6 +16,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <string.h>
+#include <argz.h>
 #include "maplec.h"
 
 #define DATA_BEGIN   ((char) 2)
@@ -105,6 +106,36 @@ static void M_DECL errorCallBack( void *data, M_INT offset, const char *msg )
 }
 
 /******************************************************************************
+* Banner
+******************************************************************************/
+
+static void banner(MKernelVector kv) {
+	const char* kversion=MapleToString(kv,MapleKernelOptions(kv,"version",NULL));
+	char * kversionz=NULL;
+	size_t kversionz_len=0;
+	argz_create_sep(kversion,',',&kversionz,&kversionz_len);
+	char* kversionv[argz_count(kversionz,kversionz_len)+1];
+	argz_extract(kversionz,kversionz_len,kversionv);
+	char* krelease=strrchr(kversionv[0],' '); while (*krelease == ' ') ++krelease;
+	char* kplatform=kversionv[1]; while (*kplatform == ' ') ++kplatform;
+	char* kdate=kversionv[2]; while (*kdate == ' ') ++kdate;
+	char* kvbid=kversionv[3]; while (*kvbid == ' ') ++kvbid;
+	char* kyear=strrchr(kdate,' '); while (*kyear == ' ') ++kyear;
+	char* kbid=strrchr(kvbid,' '); while (*kbid == ' ') ++kbid;
+
+  printf("    |\\^/|     OpenMaple/Maple %s+b%s (%s) %s\n",krelease,kbid,kplatform,kdate);
+  printf("._|\\|   |/|_. Copyright (c) Maplesoft, a division of Waterloo Maple Inc. %s\n",kyear);
+  printf(" \\OPENMAPLE/  All rights reserved. Maple and OpenMaple are trademarks of\n");
+  printf(" <____ ____>  Waterloo Maple Inc.\n");
+  printf("      |       Type ? for help.\n");
+  printf("\nTeXmacs interface by Joris van der Hoeven\n");
+
+	krelease=kplatform=kdate=kvbid=kyear=kbid=NULL;
+	*kversionv=NULL;
+	free(kversionz); kversionz=NULL; kversionz_len=0;
+}
+
+/******************************************************************************
 * Launching maple
 ******************************************************************************/
 
@@ -137,19 +168,16 @@ main (int argc, char *argv[]) {
 	}
 
   signal(SIGINT,catch_intr);
-  printf("\2verbatim:");
-  printf("    |\\^/|     Maple\n");
-  printf("._|\\|   |/|_. Copyright (c) Maplesoft, a division of Waterloo Maple Inc. 2004\n");
-  printf(" \\OPENMAPLE/  All rights reserved. Maple and OpenMaple are trademarks of\n");
-  printf(" <____ ____>  Waterloo Maple Inc.\n");
-  printf("      |       Type ? for help.\n");
-  printf("\nTeXmacs interface by Joris van der Hoeven\n");
 
   /* initialize Maple */
   if( (kv=StartMaple(argc,argv,&cb,in,NULL,err)) == NULL ) {
     printf("Fatal error, %s\n",err);
     return( 1 );
   }
+
+  /* show banner */
+  printf("\2verbatim:");
+  banner(kv);
 
   r= EvalMapleStatement (kv, "tmmaple:=9:protect('tmmaple'):");
 	snprintf(in,sizeof(in),"read(`%s`);",tmmplinit);

--- a/plugins/maple/src.9/tm_maple_9.c
+++ b/plugins/maple/src.9/tm_maple_9.c
@@ -16,7 +16,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <string.h>
-#include <argz.h>
 #include "maplec.h"
 
 #define DATA_BEGIN   ((char) 2)
@@ -111,15 +110,11 @@ static void M_DECL errorCallBack( void *data, M_INT offset, const char *msg )
 
 static void banner(MKernelVector kv) {
 	const char* kversion=MapleToString(kv,MapleKernelOptions(kv,"version",NULL));
-	char * kversionz=NULL;
-	size_t kversionz_len=0;
-	argz_create_sep(kversion,',',&kversionz,&kversionz_len);
-	char* kversionv[argz_count(kversionz,kversionz_len)+1];
-	argz_extract(kversionz,kversionz_len,kversionv);
-	char* krelease=strrchr(kversionv[0],' '); while (*krelease == ' ') ++krelease;
-	char* kplatform=kversionv[1]; while (*kplatform == ' ') ++kplatform;
-	char* kdate=kversionv[2]; while (*kdate == ' ') ++kdate;
-	char* kvbid=kversionv[3]; while (*kvbid == ' ') ++kvbid;
+	char* kversionv=strdup(kversion);
+	char* kplatform=strchr(kversionv,','); *kplatform='\0'; do ++kplatform; while (*kplatform == ' ');
+	char* krelease=strrchr(kversionv,' '); while (*krelease == ' ') ++krelease;
+	char* kdate=strchr(kplatform,','); *kdate='\0'; do ++kdate; while (*kdate == ' ');
+	char* kvbid=strchr(kdate,','); *kvbid='\0'; do ++kvbid; while (*kvbid == ' ');
 	char* kyear=strrchr(kdate,' '); while (*kyear == ' ') ++kyear;
 	char* kbid=strrchr(kvbid,' '); while (*kbid == ' ') ++kbid;
 
@@ -131,8 +126,7 @@ static void banner(MKernelVector kv) {
   printf("\nTeXmacs interface by Joris van der Hoeven\n");
 
 	krelease=kplatform=kdate=kvbid=kyear=kbid=NULL;
-	*kversionv=NULL;
-	free(kversionz); kversionz=NULL; kversionz_len=0;
+	free(kversionv); kversionv=NULL;
 }
 
 /******************************************************************************

--- a/plugins/maple/src.9/tm_maple_9.c
+++ b/plugins/maple/src.9/tm_maple_9.c
@@ -108,9 +108,12 @@ static void M_DECL errorCallBack( void *data, M_INT offset, const char *msg )
 * Launching maple
 ******************************************************************************/
 
+#define TMMPL_PI_MAPLEINIT_RELPATH "plugins/maple/maple/init-maple.mpl"
+
 int
 main (int argc, char *argv[]) {
   const char* tm_path=getenv("TEXMACS_PATH");
+  const char* tm_home_path=getenv("TEXMACS_HOME_PATH");
   char in [2148];
   char err[2048];
 	char tmmplinit [2048];
@@ -127,7 +130,7 @@ main (int argc, char *argv[]) {
                            };
   ALGEB r, l;  /* Maple data-structures */
 
-	snprintf(tmmplinit,sizeof(tmmplinit),"%s/plugins/maple/maple/init-maple.mpl",tm_path);
+	snprintf(tmmplinit,sizeof(tmmplinit), "%s/" TMMPL_PI_MAPLEINIT_RELPATH ,tm_path);
 	if (access(tmmplinit,R_OK)) {
 		printf("Fatal error, unable to read `%s`\n",tmmplinit);
 		return( 1 );
@@ -152,6 +155,12 @@ main (int argc, char *argv[]) {
 	snprintf(in,sizeof(in),"read(`%s`);",tmmplinit);
   r= EvalMapleStatement (kv, in);
 
+	snprintf(tmmplinit,sizeof(tmmplinit), "%s/" TMMPL_PI_MAPLEINIT_RELPATH ,tm_home_path);
+	if (!(access(tmmplinit,R_OK))) {
+		snprintf(in,sizeof(in),"read(`%s`);",tmmplinit);
+		r= EvalMapleStatement (kv, in);
+	}
+
   while (1) {
     next_input ();
     printf("\5");
@@ -170,7 +179,7 @@ main (int argc, char *argv[]) {
       MapleHelp (kv, in+1, NULL, writeHelpChar, NULL, 80, NULL);
     else {
       if (in[strlen(in)-1] != ':')
-	strcat (in, ":tmresult:=\%:tmprint(tmresult):tmresult:");
+        strcat (in, ":tmresult:=\%:tmprint(tmresult):tmresult:");
       r = EvalMapleStatement (kv, in);
     }
   }
@@ -179,3 +188,5 @@ main (int argc, char *argv[]) {
 
   return (0);
 }
+
+#undef TMMPL_PI_MAPLEINIT_RELPATH

--- a/plugins/maple/src.9/tm_maple_9.c
+++ b/plugins/maple/src.9/tm_maple_9.c
@@ -88,6 +88,7 @@ static void M_DECL textCallBack( void *data, int tag, const char *output )
 
 static void M_DECL errorCallBack( void *data, M_INT offset, const char *msg )
 {
+  char* in=(char *)data;
   M_INT i;
   /* TODO: too wide (>= 80 characters) user input */
 
@@ -97,7 +98,7 @@ static void M_DECL errorCallBack( void *data, M_INT offset, const char *msg )
     /* put ^^^ under the original input to indicate where
        the syntax error probably was
     */
-    fprintf (stderr, "Syntax Error, %s\n> %s\n", msg, data);
+    fprintf (stderr, "Syntax Error, %s\n> %s\n", msg, in);
     for (i=0; i<offset; ++i)
       fputc (' ', stderr);
     fprintf (stderr, "^\n");
@@ -155,6 +156,9 @@ main (int argc, char *argv[]) {
                            };
   ALGEB r, l;  /* Maple data-structures */
 
+  (void) r;  /* silence unused-but-set-variable warning */
+  (void) l;  /* silence unused-variable warning */
+
 	snprintf(tmmplinit,sizeof(tmmplinit), "%s/" TMMPL_PI_MAPLEINIT_RELPATH ,tm_path);
 	if (access(tmmplinit,R_OK)) {
 		printf("Fatal error, unable to read `%s`\n",tmmplinit);
@@ -164,7 +168,7 @@ main (int argc, char *argv[]) {
   signal(SIGINT,catch_intr);
 
   /* initialize Maple */
-  if( (kv=StartMaple(argc,argv,&cb,in,NULL,err)) == NULL ) {
+  if( (kv=StartMaple(argc,argv,&cb,(void *)in,NULL,err)) == NULL) {
     printf("Fatal error, %s\n",err);
     return( 1 );
   }


### PR DESCRIPTION
This is a bunch of three patches that gradually improves the current maple plugin:
- the first patch fixes and refreshes the current maple plugin machinery;
- the second patch allows to read an `init-maple.mpl` maple script placed under the `TEXMACS_HOME_PATH` hierarchy;
- the third patch makes the current banner more informative.