### PR TITLE
mupad plugin: migration to shebang

### DIFF
--- a/plugins/mupad/bin/tm_mupad
+++ b/plugins/mupad/bin/tm_mupad
@@ -1,5 +1,4 @@
-:
-#!/bin/bash -- # -*- perl -*-
+#!/usr/bin/perl
 # $Id$
 #
 # MuPAD <-> TeXmacs communication link.


### PR DESCRIPTION
Description: upstream: migration: shebang
 Proper invocation of perl (Ralf Treinen). Migrate from colon-bang (or something) to shebang: the comment by Perderabo at <www.unix.com> [here](https://www.unix.com/shell-programming-and-scripting/10193-just-first-line-shell.html) gives some clue.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Author: Ralf Treinen <treinen@debian.org>
Last-Update: 2024-08-15