### PR TITLE
harden the building machinery of the plugin examples

### DIFF
--- a/TeXmacs/examples/plugins/complete/Makefile
+++ b/TeXmacs/examples/plugins/complete/Makefile
@@ -10,18 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
-
-$(shell [ -d bin ] || mkdir -p bin)
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/dynlink/Makefile.in
+++ b/TeXmacs/examples/plugins/dynlink/Makefile.in
@@ -1,6 +1,6 @@
 
 ###############################################################################
-# MODULE     : Make file for plugin example with dynamic links
+# MODULE     : Make file for plugin example
 # COPYRIGHT  : (C) 1999-2008  Joris van der Hoeven
 ###############################################################################
 # This software falls under the GNU general public license version 3 or later.
@@ -8,17 +8,29 @@
 # in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ###############################################################################
 
-tmsrc = @tmsrc@
-CXX = g++
-LD  = g++
-RM  = rm -f
+tmsrc ?= @tmsrc@
 
-lib/libtmdynlink.so: src/dynlink.cpp
-	$(CXX) -I$(tmsrc)/include -c src/dynlink.cpp -o src/dynlink.o
-	$(LD) -shared -o lib/libtmdynlink.so src/dynlink.o
+CXX = g++
+LD = g++
+RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
+
+CPPFLAGS += -I$(tmsrc)/include
+
+FILES_CPP := $(wildcard src/*.cpp)
+FILES_LIB := $(patsubst src/%.cpp,lib/libtm%.so,$(FILES_CPP))
+
+all: $(FILES_LIB)
+
+lib/libtm%.so : src/%.cpp | lib
+	$(LD) -shared $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $< -o $@ $(LIBADD)
+
+lib:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
-	$(RM) */*.o
 	$(RM) lib/*
+	test -d lib && $(RMDIR) lib || true

--- a/TeXmacs/examples/plugins/formula/Makefile
+++ b/TeXmacs/examples/plugins/formula/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/handler/Makefile
+++ b/TeXmacs/examples/plugins/handler/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/handler/src/handler.cpp
+++ b/TeXmacs/examples/plugins/handler/src/handler.cpp
@@ -10,6 +10,7 @@
 ******************************************************************************/
 
 #include <iostream>
+#include <cstring>
 using namespace std;
 
 #define DATA_BEGIN   ((char) 2)

--- a/TeXmacs/examples/plugins/input/Makefile
+++ b/TeXmacs/examples/plugins/input/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/markup/Makefile
+++ b/TeXmacs/examples/plugins/markup/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/menus/Makefile
+++ b/TeXmacs/examples/plugins/menus/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/minimal/Makefile
+++ b/TeXmacs/examples/plugins/minimal/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/multiline/Makefile
+++ b/TeXmacs/examples/plugins/multiline/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/multiline/src/multiline.cpp
+++ b/TeXmacs/examples/plugins/multiline/src/multiline.cpp
@@ -11,6 +11,7 @@
 ******************************************************************************/
 
 #include <iostream>
+#include <cstring>
 using namespace std;
 
 #define DATA_BEGIN   ((char) 2)

--- a/TeXmacs/examples/plugins/nested/Makefile
+++ b/TeXmacs/examples/plugins/nested/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/pnambic/Makefile
+++ b/TeXmacs/examples/plugins/pnambic/Makefile
@@ -1,10 +1,28 @@
-all: EMPTY_DIRS bin/p_out bin/p_in bin/pnambic in out
 
-EMPTY_DIRS:
-	mkdir -p bin
+###############################################################################
+# MODULE     : Make file for plugin example
+# COPYRIGHT  : (C) 1999-2008  Joris van der Hoeven
+###############################################################################
+# This software falls under the GNU general public license version 3 or later.
+# It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+# in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+###############################################################################
 
-bin/%: src/%.c
-	gcc -o $@ $<
+CC = gcc
+RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
+
+FILES_C := $(wildcard src/*.c)
+FILES_BIN := $(patsubst src/%.c,bin/%.bin,$(FILES_C))
+
+all: $(FILES_BIN) in out
+
+bin/%.bin : src/%.c | bin
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 in:
 	mkfifo in
@@ -13,6 +31,8 @@ out:
 	mkfifo out
 
 clean:
-	rm -f in out bin/* src/*~ progs/*~ *~
-
-.PHONY: all clean
+	$(RM) *~
+	$(RM) */*~
+	$(RM) bin/*
+	$(RM) in out
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/pnambic/src/p_in.c
+++ b/TeXmacs/examples/plugins/pnambic/src/p_in.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdio.h>
 #include <stdio_ext.h>
 

--- a/TeXmacs/examples/plugins/pnambic/src/p_out.c
+++ b/TeXmacs/examples/plugins/pnambic/src/p_out.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdio.h>
 
 int main(int argc,char **argv)

--- a/TeXmacs/examples/plugins/pnambic/src/pnambic.c
+++ b/TeXmacs/examples/plugins/pnambic/src/pnambic.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/TeXmacs/examples/plugins/prompt/Makefile
+++ b/TeXmacs/examples/plugins/prompt/Makefile
@@ -10,18 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
-
-$(shell [ -d bin ] || mkdir -p bin)
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/secure/Makefile
+++ b/TeXmacs/examples/plugins/secure/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true

--- a/TeXmacs/examples/plugins/substitute/Makefile
+++ b/TeXmacs/examples/plugins/substitute/Makefile
@@ -10,16 +10,22 @@
 
 CXX = g++
 RM = rm -f
+MKDIR_P = mkdir -p
+RMDIR = rmdir --i
 
 FILES_CPP := $(wildcard src/*.cpp)
 FILES_BIN := $(patsubst src/%.cpp,bin/%.bin,$(FILES_CPP))
 
 all: $(FILES_BIN)
 
-bin/%.bin : src/%.cpp
-	$(CXX) $< -o $@
+bin/%.bin : src/%.cpp | bin
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+bin:
+	$(MKDIR_P) $@
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/*
+	test -d bin && $(RMDIR) bin || true


### PR DESCRIPTION
Description: upstream: harden: examples: plugins: Makefile_s
 This patch refreshes the building machineries as provided for
 the plugin examples. Alongside, it renders the Makefile_s
 more appropriate and more flexible for ``experimentations``.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _AT_ rezozer _DOT_ net >
Last-Update: 2024-08-15