### PR TITLE
harden plugins Makefile_s

### DIFF
--- a/plugins/axiom/Makefile
+++ b/plugins/axiom/Makefile
@@ -8,13 +8,13 @@
 # in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ###############################################################################
 
-CC = gcc
-RM = rm -f
+CC ?= gcc
+RM ?= rm -f
 
 all: bin/tm_axiom
 
-bin/tm_axiom: src/tm_axiom.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) src/tm_axiom.c -o bin/tm_axiom
+bin/% : src/%.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDADD)
 
 clean:
 	$(RM) bin/tm_axiom

--- a/plugins/maple/Makefile
+++ b/plugins/maple/Makefile
@@ -8,18 +8,16 @@
 # in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ###############################################################################
 
-CC = gcc
-CXX = g++
-RM = rm -f
+CC ?= gcc
+CXX ?= g++
+RM ?= rm -f
 
 all: bin/tm_maple_5
 
-bin/tm_maple_5: src/tm_maple_5.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) src/tm_maple_5.cpp -o bin/tm_maple_5
+bin/% : src/%.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@ $(LDFLAGS) $(LDADD)
 
 clean:
 	$(RM) *~
 	$(RM) */*~
 	$(RM) bin/tm_maple_5
-	$(RM) $(HOME)/.TeXmacs/bin/tm_maple_9.sh
-	$(RM) $(HOME)/.TeXmacs/bin/tm_maple_9

--- a/plugins/r/Makefile
+++ b/plugins/r/Makefile
@@ -8,13 +8,16 @@
 # in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ###############################################################################
 
-CC = gcc
-RM = rm -f
+CC ?= gcc
+RM ?= rm -f
+
+CPPFLAGS += -I../../src/System
+LDADD += -lutil
 
 all: bin/tm_r
 
-bin/tm_r: src/tm_r.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -I../../src/System src/tm_r.c -o bin/tm_r -lutil
+bin/% : src/%.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDADD)
 
 clean:
 	$(RM) bin/tm_r

--- a/plugins/shell/Makefile
+++ b/plugins/shell/Makefile
@@ -8,13 +8,16 @@
 # in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ###############################################################################
 
-CXX = g++
-RM = rm -f
+CXX ?= g++
+RM ?= rm -f
 
 all: bin/tm_shell
 
-bin/tm_shell: src/tm_shell.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I../../src/System src/tm_shell.cpp -o bin/tm_shell -lutil
+CPPFLAGS += -I../../src/System
+LDADD += -lutil
+
+bin/% : src/%.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@ $(LDFLAGS) $(LDADD)
 
 clean:
 	$(RM) bin/tm_shell


### PR DESCRIPTION
Description: upstream: harden: plugins: Makefile_s
 This patch hardens the Makefile_s used to compile
 the C/C++ plugins.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _AT_ rezozer _DOT_ net >
Last-Update: 2024-08-15