### PR TITLE
correct inconsistency in init_texmacs

### DIFF
--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -67,9 +67,9 @@ plugin_path (string which) {
 scheme_tree
 plugin_list () {
   bool flag;
-  array<string> a= read_directory ("$TEXMACS_PATH/plugins", flag);
+  array<string> a= read_directory ("$TEXMACS_HOME_PATH/plugins", flag);
   a << read_directory ("/etc/TeXmacs/plugins", flag);
-  a << read_directory ("$TEXMACS_HOME_PATH/plugins", flag);
+  a << read_directory ("$TEXMACS_PATH/plugins", flag);
   a << read_directory ("/usr/share/TeXmacs/plugins", flag);
   merge_sort (a);
   int i, n= N(a);


### PR DESCRIPTION
Description: upstream: correct: inconsistency: init_texmacs
 Correct an inconsistency spotted by hand in `s/S/B/init_texmacs.cpp`. The functions `plugin_path` and `plugin_list` play with list of paths that might have to follow the same order. Currently the two lists follow the same order but up to an apparent typo. This patch corrects the typo by assuming that the correct order is the traditional one used in Un*x.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _AT_  debian _DOT_ org >
Last-Update: 2024-08-19