### PR TITLE
[SVN] CLI enhancement:  --homedir option

### DIFF
--- a/src/Texmacs/Texmacs/texmacs.cpp
+++ b/src/Texmacs/Texmacs/texmacs.cpp
@@ -302,6 +302,10 @@ TeXmacs_main (int argc, char** argv) {
         cout << get_env ("TEXMACS_PATH") << "\n";
         exit (0);
       }
+      else if ((s == "-hp") || (s == "-homepath")) {
+        cout << get_env ("TEXMACS_HOME_PATH") << "\n";
+        exit (0);
+      }
       else if ((s == "-bp") || (s == "-binpath")) {
         cout << get_env ("TEXMACS_BIN_PATH") << "\n";
         exit (0);


### PR DESCRIPTION
Description: upstream: enhance: cli: option: homepath
 Introduce the option `--homepath` (or `-hp`) as companion of the options `--path` (or `-p`) and `--binpath` (or `-bp`).
 These options can be useful in scripts, in particular in plugins `Makefile_s`. Note that this patch adds no entry in the _help message_. This follows the policy chosen for the option `--bindir`.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _AT_ debian _DOT_ org >
Last-Update: 2024-08-21