### PR TITLE
correct typo in Sections 13.4-5 of the User Manual

### DIFF
--- a/TeXmacs/doc/devel/plugin/plugin-binary.de.tm
+++ b/TeXmacs/doc/devel/plugin/plugin-binary.de.tm
@@ -29,8 +29,8 @@
     \ \ \ \ $TEXMACS_PATH/examples/plugins/minimal
   </verbatim>
 
-  rekursiv in das Verzeichnis <verbatim|$TEXMACS_PATH/progs> kopieren oder in
-  das Verzeichnis <verbatim|$TEXMACS_HOME_PATH/progs>. Danach müssen Sie in
+  rekursiv in das Verzeichnis <verbatim|$TEXMACS_PATH/plugins> kopieren oder in
+  das Verzeichnis <verbatim|$TEXMACS_HOME_PATH/plugins>. Danach müssen Sie in
   dem Verzeichnis minimal den Befehl
 
   <\verbatim>

--- a/TeXmacs/doc/devel/plugin/plugin-binary.en.tm
+++ b/TeXmacs/doc/devel/plugin/plugin-binary.en.tm
@@ -30,7 +30,7 @@
     \ \ \ \ $TEXMACS_PATH/examples/plugins/minimal
   </verbatim>
 
-  to <verbatim|$TEXMACS_PATH/progs> or <verbatim|$TEXMACS_HOME_PATH/progs>.
+  to <verbatim|$TEXMACS_PATH/plugins> or <verbatim|$TEXMACS_HOME_PATH/plugins>.
   Next, running the <verbatim|Makefile> using
 
   <\verbatim>

--- a/TeXmacs/doc/devel/plugin/plugin-binary.it.tm
+++ b/TeXmacs/doc/devel/plugin/plugin-binary.it.tm
@@ -31,7 +31,7 @@
     \ \ \ \ $TEXMACS_PATH/examples/plugins/minimal
   </verbatim>
 
-  in <verbatim|$TEXMACS_PATH/progs> o in <verbatim|$TEXMACS_HOME_PATH/progs>.
+  in <verbatim|$TEXMACS_PATH/plugins> o in <verbatim|$TEXMACS_HOME_PATH/plugins>.
   Quindi si esegue <verbatim|Makefile> utilizzando
 
   <\verbatim>

--- a/TeXmacs/doc/devel/plugin/plugin-python.en.tm
+++ b/TeXmacs/doc/devel/plugin/plugin-python.en.tm
@@ -28,7 +28,7 @@
     \ \ \ \ $TEXMACS_PATH/examples/plugins/pyminimal
   </verbatim>
 
-  to <verbatim|$TEXMACS_PATH/progs> or <verbatim|$TEXMACS_HOME_PATH/progs>.
+  to <verbatim|$TEXMACS_PATH/plugins> or <verbatim|$TEXMACS_HOME_PATH/plugins>.
 
   When relaunching <TeXmacs>, the plug-in should now be automatically
   recognized.


### PR DESCRIPTION
Description: upstream: typo: doc on plugins
 Correct a typo spotted by hand in Sections 13.4-5: plugins material must be recurcively copy neither in `$TEXMACS_PATH/progs` nor `$TEXMACS_HOME_PATH/progs` but in `$TEXMACS_PATH/plugins` or `$TEXMACS_HOME_PATH/plugins`.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2024-08-22