### PR TITLE
doc enhancement: introduce texmacs-source-manual

### DIFF
--- a/TeXmacs/progs/utils/test/test-convert.scm
+++ b/TeXmacs/progs/utils/test/test-convert.scm
@@ -166,6 +166,8 @@
                       (string-append "main/man-reference." lan ".tm"))
                      ((== name "texmacs-scheme-manual")
                       (string-append "devel/scheme/scheme." lan ".tm"))
+                     ((== name "texmacs-source-manual")
+                      (string-append "devel/source/source." lan ".tm"))
                      (else "unknown.en.tm")))
          (doc-dir "$TEXMACS_DOC_PATH"))
     (if (url-exists? (url-unix doc-dir root))


### PR DESCRIPTION
Description: upstream: enhance: doc: texmacs-source-manual
 Add the _Developers guide_ (Help->Full manuals->Developers guide) to the list of pre-defined manuals that we can build with the long-option `--build-manual`.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _AT_ debian _DOT_ net >
Last-Update: 2024-08-22