### PR TITLE
asymptote plugin fix

### DIFF
--- a/plugins/tmpy/graph/asymptote.py
+++ b/plugins/tmpy/graph/asymptote.py
@@ -37,7 +37,7 @@ class Asymptote(Graph):
         with open(code_path, 'w') as code_file:
             code_file.write(code)
 
-        cmd = [self.name, "-quiet", "-feps", "-o", self.get_eps_path(), code_path]
+        cmd = [self.name, "-quiet", "-feps", "-o", self.get_eps_path_prefix(), code_path]
         p = Popen(cmd, stderr=PIPE)
         out, err = p.communicate()
         if (p.returncode == 0):

--- a/plugins/tmpy/graph/graph.py
+++ b/plugins/tmpy/graph/graph.py
@@ -126,6 +126,9 @@ class Graph(object):
     def get_png_path(self):
         return self.get_tmp_dir() + self.name + ".png"
 
+    def get_eps_path_prefix(self):
+        return self.get_tmp_dir() + self.name
+
     def get_eps_path(self):
         return self.get_tmp_dir() + self.name + ".eps"
 


### PR DESCRIPTION
Description: fix: plugins: asymptote: path prefix
 Pass to `asy` the outname option `-o` (or `--outname`)
 with as argument the prefix of the EPS file instead of
 its name. It appears that `asy` adds the extension `.eps`
 to the `-o` argument to obtain the file name of the EPS
 output. This change is consistent with the manpage of `asy`
 (on GNU/Linux at least) which specifies the argument as being
 an _[a]lternatice output directory/file prefix_.
Origin: vendor, Debian
Author: Jerome Benoit < calculus _AT_ debian _DOT_ org >
Last-Update: 2024-08-23