### PR TITLE
hashtree: fix build with clang-19

### DIFF
--- a/src/Kernel/Containers/hashtree.cpp
+++ b/src/Kernel/Containers/hashtree.cpp
@@ -94,7 +94,7 @@ hashtree<K,V>::operator-> (void) {
 
 template<class K, class V> inline hashtree<K,V> 
 hashtree<K,V>::operator[] (K key) {
-  if (*this->contains (key)) return *this->children (key);
+  if ((*this)->contains (key)) return (*this)->children (key);
   else FAILED ("read-access to non-existent node requested");
 }
   


### PR DESCRIPTION
```
hashtree.cpp:97:14: error: no member named 'contains' in 'hashtree<K, V>'
   97 |   if (*this->contains (key)) return *this->children (key);
      |        ~~~~  ^
hashtree.cpp:97:44: error: no member named 'children' in 'hashtree<K, V>'
   97 |   if (*this->contains (key)) return *this->children (key);
      |                                      ~~~~  ^
2 errors generated.
```

add parentheses around (*this) to fix build failure.

alternatively can just delete the function as it is unused -- clang-19 and gcc-15 will report errors in unused code


https://github.com/NixOS/nixpkgs/pull/373205#pullrequestreview-2545476272