### PR TITLE
Macaulay2 plugin updates

### DIFF
--- a/TeXmacs/doc/about/authors/about-plugins.de.tm
+++ b/TeXmacs/doc/about/authors/about-plugins.de.tm
@@ -18,7 +18,7 @@
 
     <item*|GTybalt>Stefan Weinzierl.
 
-    <item*|Macaulay 2>Dan Grayson.
+    <item*|Macaulay2>Dan Grayson.
 
     <item*|Maple>Christian Even.
 

--- a/TeXmacs/doc/about/authors/about-plugins.en.tm
+++ b/TeXmacs/doc/about/authors/about-plugins.en.tm
@@ -32,7 +32,7 @@
 
     <item*|Lush>Michael Graffam.
 
-    <item*|Macaulay 2>Dan Grayson.
+    <item*|Macaulay2>Dan Grayson.
 
     <item*|Maple>Joris van der Hoeven.
 

--- a/TeXmacs/doc/about/contribute/interfaces/interfaces.de.tm
+++ b/TeXmacs/doc/about/contribute/interfaces/interfaces.de.tm
@@ -9,7 +9,7 @@
   zu schreiben. Bitte überlegen Sie, ob eine solche Schnittstelle für die von
   Ihnen verwendeten Programme in Frage kommt und ob Sie eine solche
   Schnitt-Stelle programmieren möchten. <TeXmacs> hat bereits Schnittstellen
-  zu andren freien Systemen wie Giac, Macaulay 2, Maxima, GNU Octave, Pari,
+  zu andren freien Systemen wie Giac, Macaulay2, Maxima, GNU Octave, Pari,
   Qcl, gTybalt und Yacas. Detaillierte Informationen, wie man vorgeht, finden
   Sie unter <hyper-link|<menu|Help|Interfacing>|../../../devel/plugin/plugins.de.tm>.
 

--- a/TeXmacs/doc/about/contribute/interfaces/interfaces.en.tm
+++ b/TeXmacs/doc/about/contribute/interfaces/interfaces.en.tm
@@ -9,7 +9,7 @@
   systems or other scientific programs with structured output. Please
   consider writing interfaces between <TeXmacs> and your favorite system(s).
   <TeXmacs> has already been interfaced with several other free systems, like
-  Giac, Macaulay 2, Maxima, GNU Octave, Pari, Qcl, gTybalt, Yacas. Detailed
+  Giac, Macaulay2, Maxima, GNU Octave, Pari, Qcl, gTybalt, Yacas. Detailed
   documentation on how to add new interfaces is available in the
   <hyper-link|<menu|Help|Interfacing>|../../../devel/plugin/plugin.en.tm>
   menu.

--- a/TeXmacs/doc/about/contribute/interfaces/interfaces.es.tm
+++ b/TeXmacs/doc/about/contribute/interfaces/interfaces.es.tm
@@ -9,7 +9,7 @@
   álgebra computacional u otros programas científicos con salida
   estructurada. Por favor considere escribir interfaces entre <apply|TeXmacs>
   y su(s) sistema(s) favorito(s). Ya \ ha sido hechas interfaces entre
-  <apply|TeXmacs> con varios otros sistemas libres, como Giac, Macaulay 2,
+  <apply|TeXmacs> con varios otros sistemas libres, como Giac, Macaulay2,
   Maxima, GNU Octave, Pari, Qcl, gTybalt, Yacas. Documentación detallada
   sobre cómo adicionar nuevas interfaces está disponible en el menu
   <apply|hyper-link|<apply|menu|Help|Interfacing>|../../../devel/plugin/plugin.en.tm>.

--- a/TeXmacs/doc/about/contribute/interfaces/interfaces.fr.tm
+++ b/TeXmacs/doc/about/contribute/interfaces/interfaces.fr.tm
@@ -10,7 +10,7 @@
   sorties sont structurées. N'hésitez pas à vous lancer dans l'écriture
   d'interfaces entre <apply|TeXmacs> et votre(vos) système(s) préféré(s).
   <apply|TeXmacs> a déjà été interfacé avec plusieurs systèmes gratuits,
-  comme Giac, Macaulay 2, Maxima, GNU Octave, Pari, Qcl, gTybaly, Yacas. Pour
+  comme Giac, Macaulay2, Maxima, GNU Octave, Pari, Qcl, gTybaly, Yacas. Pour
   de plus amples détails sur la façon d'ajouter de nouvelles interfaces, voir
   \ <apply|hyper-link|<apply|menu|Help|Interfacing>|../../../devel/plugin/plugin.fr.tm>.
 

--- a/TeXmacs/doc/about/contribute/interfaces/interfaces.it.tm
+++ b/TeXmacs/doc/about/contribute/interfaces/interfaces.it.tm
@@ -10,7 +10,7 @@
   strutturati. Tenete in considerazione la possibilità di scrivere
   un'interfaccia tra <apply|TeXmacs> e i vostri programmi scientifici
   preferiti. <apply|TeXmacs> è già interfacciato con numerosi altri programmi
-  scientifici come Giac, Macaulay 2, Maxima, GNU Octave, Pari, Qcl, gTybalt,
+  scientifici come Giac, Macaulay2, Maxima, GNU Octave, Pari, Qcl, gTybalt,
   Yacas. La documentazione dettagliata su come realizzare nuove interfacceè
   disponibile nel menu <apply|hyper-link|<apply|menu|Help|Interfacing>|../../../devel/plugin/plugin.en.tm>.
 

--- a/plugins/macaulay2/doc/macaulay2-abstract.en.tm
+++ b/plugins/macaulay2/doc/macaulay2-abstract.en.tm
@@ -5,7 +5,7 @@
 <\body>
   <tmdoc-title|The <name|Macaulay2> system>
 
-  <hlink|<name|Macaulay2>|http://www.math.uiuc.edu/Macaulay2> is a new
+  <hlink|<name|Macaulay2>|https://macaulay2.com/> is a new
   software system devoted to supporting research in algebraic geometry and
   commutative algebra. The software is available now in source code for
   porting, and in compiled form for <name|Linux>, <name|SunOS>,

--- a/plugins/macaulay2/doc/macaulay2-abstract.en.tm
+++ b/plugins/macaulay2/doc/macaulay2-abstract.en.tm
@@ -3,9 +3,9 @@
 <style|tmdoc>
 
 <\body>
-  <tmdoc-title|The <name|Macaulay 2> system>
+  <tmdoc-title|The <name|Macaulay2> system>
 
-  <hlink|<name|Macaulay 2>|http://www.math.uiuc.edu/Macaulay2> is a new
+  <hlink|<name|Macaulay2>|http://www.math.uiuc.edu/Macaulay2> is a new
   software system devoted to supporting research in algebraic geometry and
   commutative algebra. The software is available now in source code for
   porting, and in compiled form for <name|Linux>, <name|SunOS>,

--- a/plugins/macaulay2/doc/macaulay2-demo.en.tm
+++ b/plugins/macaulay2/doc/macaulay2-demo.en.tm
@@ -4,11 +4,11 @@
 
 <\body>
   <\tmdoc-title>
-    Example <name|Macaulay 2> session
+    Example <name|Macaulay2> session
   </tmdoc-title>
 
-  Using <menu|Insert|Session|Macaulay2>, you may insert a new <name|Macaulay
-  2> session. Here follows a sample session.
+  Using <menu|Insert|Session|Macaulay2>, you may insert a new <name|Macaulay2>
+  session. Here follows a sample session.
 
   <\session|macaulay2|default>
     <\output>

--- a/plugins/macaulay2/doc/macaulay2-demo.it.tm
+++ b/plugins/macaulay2/doc/macaulay2-demo.it.tm
@@ -4,10 +4,10 @@
 
 <\body>
   <\tmdoc-title>
-    Usare sessioni di Macaulay 2 in <TeXmacs>
+    Usare sessioni di Macaulay2 in <TeXmacs>
   </tmdoc-title>
 
-  <name|Macaulay 2> è un software dedicato al supporto della ricerca in
+  <name|Macaulay2> è un software dedicato al supporto della ricerca in
   geometria algebrica e algebra commutativa. Questo software è ora
   disponibile come codice sorgente e in forme compilate per <name|Linux>,
   <name|Sun OS>, <name|Solaris>, <name|Windows>, e per alcune altre macchine
@@ -18,7 +18,7 @@
   </verbatim>
 
   Qui di seguito vi è un esempio di una sessione, che si può iniziare usando
-  <menu|Insert|Session|Macaulay 2>:
+  <menu|Insert|Session|Macaulay2>:
 
   <\session|macaulay2|default>
     <\output>

--- a/plugins/macaulay2/doc/macaulay2-demo.it.tm
+++ b/plugins/macaulay2/doc/macaulay2-demo.it.tm
@@ -14,7 +14,7 @@
   unix. Lo si può scaricare da
 
   <\verbatim>
-    \ \ \ \ http://www.math.uiuc.edu/Macaulay2
+    \ \ \ \ https://macaulay2.com/
   </verbatim>
 
   Qui di seguito vi è un esempio di una sessione, che si può iniziare usando

--- a/plugins/macaulay2/doc/macaulay2.en.tm
+++ b/plugins/macaulay2/doc/macaulay2.en.tm
@@ -3,7 +3,7 @@
 <style|tmdoc>
 
 <\body>
-  <tmdoc-title|The <name|Macaulay 2> plug-in>
+  <tmdoc-title|The <name|Macaulay2> plug-in>
 
   <\traverse>
     <branch|Short description|macaulay2-abstract.en.tm>

--- a/plugins/macaulay2/packages/session/macaulay2.ts
+++ b/plugins/macaulay2/packages/session/macaulay2.ts
@@ -7,7 +7,7 @@
     <src-package|macaulay2|1.0>
 
     <\src-purpose>
-      Markup for Macaulay 2 sessions.
+      Markup for Macaulay2 sessions.
     </src-purpose>
 
     <src-copyright|2002--2004|Joris van der Hoeven>

--- a/plugins/macaulay2/progs/init-macaulay2.scm
+++ b/plugins/macaulay2/progs/init-macaulay2.scm
@@ -2,7 +2,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : init-macaulay2.scm
-;; DESCRIPTION : Initialize Macaulay 2 plugin
+;; DESCRIPTION : Initialize Macaulay2 plugin
 ;; COPYRIGHT   : (C) 1999  Joris van der Hoeven
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -15,7 +15,7 @@
   (:macpath "Macaulay2*" "bin")
   (:require (url-exists-in-path? "M2"))
   (:launch "M2 --texmacs")
-  (:session "Macaulay 2"))
+  (:session "Macaulay2"))
 
 (when (supports-macaulay2?)
   (import-from (doc help-funcs))

--- a/plugins/macaulay2/progs/m2-input.scm
+++ b/plugins/macaulay2/progs/m2-input.scm
@@ -2,7 +2,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : m2-input.scm
-;; DESCRIPTION : Macaulay 2 input converters
+;; DESCRIPTION : Macaulay2 input converters
 ;; COPYRIGHT   : (C) 1999  Joris van der Hoeven
 ;;
 ;; This software falls under the GNU general public license version 3 or later.

--- a/plugins/sage/doc/sage-abstract.en.tm
+++ b/plugins/sage/doc/sage-abstract.en.tm
@@ -11,7 +11,7 @@
   mathematical computations. It is written in
   <hlink|<name|Python>|http://python.org/> and provides interfaces for a wide
   variety of other systems, such as <name|Axiom>, <name|Gap>, <name|Pari GP>,
-  <name|Macaulay<nbsp>2>, <name|Maxima>, <name|Octave>, and <name|Singular>.
+  <name|Macaulay2>, <name|Maxima>, <name|Octave>, and <name|Singular>.
   The system was started by <hlink|<name|William
   Stein>|https://www.wstein.org/>.
 

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -412,7 +412,7 @@ init_misc () {
 static void
 init_deprecated () {
 #ifndef OS_WIN32
-  // Check for Macaulay 2
+  // Check for Macaulay2
   if (get_env ("M2HOME") == "")
     if (exists_in_path ("M2")) {
       string where= concretize (resolve_in_path ("M2"));


### PR DESCRIPTION
Two small changes:

* Rename "Macaulay 2" -> "Macaulay2" everywhere (the space was dropped from the name some time ago).
* Update the URL (the old link is broken).