### PR TITLE
WIP: Declare change_time to return time_t

### DIFF
--- a/TeXmacs/doc/devel/scheme/api/glue-auto-doc.en.tm
+++ b/TeXmacs/doc/devel/scheme/api/glue-auto-doc.en.tm
@@ -9015,7 +9015,7 @@ source code.
 <explain-synopsis|no synopsis>
   <|explain>
     Calls the <c++> function <cpp|change_time> which returns
-    <scm|int>.
+    <scm|time_t>.
   </explain>
 
   <\explain>

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -628,7 +628,7 @@ edit_interface_rep::idle_time (int event_type) {
   else return 0;
 }
 
-int
+time_t
 edit_interface_rep::change_time () {
   return last_change;
 }

--- a/src/Edit/Interface/edit_interface.hpp
+++ b/src/Edit/Interface/edit_interface.hpp
@@ -133,7 +133,7 @@ public:
   void notify_change (int env_set, int env_unset = 0);
   bool has_changed (int question);
   int  idle_time (int event_type= ANY_EVENT);
-  int  change_time ();
+  time_t change_time ();
   void update_menus ();
   int  find_alt_selection_index (range_set alt_sel, SI y, int b, int e);
   void apply_changes ();

--- a/src/Edit/editor.hpp
+++ b/src/Edit/editor.hpp
@@ -172,7 +172,7 @@ public:
   virtual void notify_change (int env_set, int env_unset = 0) = 0;
   virtual bool has_changed (int question) = 0;
   virtual int  idle_time (int event_type= ANY_EVENT) = 0;
-  virtual int  change_time () = 0;
+  virtual time_t change_time () = 0;
   virtual void full_screen_mode (bool flag) = 0;
   virtual void before_menu_action () = 0;
   virtual void after_menu_action () = 0;

--- a/src/Scheme/Glue/glue_basic.cpp
+++ b/src/Scheme/Glue/glue_basic.cpp
@@ -540,10 +540,10 @@ tmg_language_to_locale (tmscm arg1) {
 tmscm
 tmg_texmacs_time () {
   // TMSCM_DEFER_INTS;
-  int out= texmacs_time ();
+  long long out= texmacs_time ();
   // TMSCM_ALLOW_INTS;
 
-  return int_to_tmscm (out);
+  return long_to_tmscm (out); // FIXME long_long_to_tmscm
 }
 
 tmscm

--- a/src/Scheme/Glue/glue_editor.cpp
+++ b/src/Scheme/Glue/glue_editor.cpp
@@ -3548,10 +3548,10 @@ tmg_idle_time () {
 tmscm
 tmg_change_time () {
   // TMSCM_DEFER_INTS;
-  int out= get_current_editor()->change_time ();
+  long long out= get_current_editor()->change_time ();
   // TMSCM_ALLOW_INTS;
 
-  return int_to_tmscm (out);
+  return long_to_tmscm (out); // FIXME should be long_long_to_tmscm ?
 }
 
 tmscm


### PR DESCRIPTION
Declare `change_time` to return `time_t` so that it can work after 2038-01-19

also adapt `texmacs_time` scm

Note: I tested that it compiles, but cannot easily test it.