### PR TITLE
[codex] Add scoped statistics summary

### DIFF
--- a/TeXmacs/progs/check/check-master.scm
+++ b/TeXmacs/progs/check/check-master.scm
@@ -20,7 +20,8 @@
         (convert tools environment-test)
         (convert mathml mathtm-test)
         (convert tmml tmmltm-test)
-        (prog prog-format-test))
+        (prog prog-format-test)
+        (texmacs texmacs tm-tools-test))
         (utils cite cite-sort-test))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -89,5 +90,6 @@
   (regtest-tmhtml)
   (regtest-tmmltm)
   (regtest-prog-format)
+  (regtest-tm-tools)
   (regtest-cite-sort)
 )

--- a/TeXmacs/progs/texmacs/menus/tools-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tools-menu.scm
@@ -71,6 +71,8 @@
   (-> "Project"
       (link project-manage-menu))
   (-> "Statistics"
+      ("Count all" (show-statistics-summary))
+      ---
       ("Count characters" (show-character-count))
       ("Count words" (show-word-count))
       ("Count lines" (show-line-count)))

--- a/TeXmacs/progs/texmacs/texmacs/tm-tools-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-tools-test.scm
@@ -1,0 +1,52 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-tools-test.scm
+;; DESCRIPTION : Test suite for tm-tools
+;; COPYRIGHT   : (C) 2026  The TeXmacs contributors
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs texmacs tm-tools-test)
+  (:use (texmacs texmacs tm-tools)))
+
+(define (statistics-count-message* args)
+  (apply statistics-count-message args))
+
+(define (statistics-summary-message* args)
+  (apply statistics-summary-message args))
+
+(define (regtest-statistics-count-message)
+  (regression-test-group
+   "statistics-count-message" "string"
+   statistics-count-message* :none
+   (test "document character count"
+         '("Document" "character" 7)
+         "Document character count: 7")
+   (test "selection word count"
+         '("Selection" "word" 3)
+         "Selection word count: 3")
+   (test "document line count"
+         '("Document" "line" 2)
+         "Document line count: 2")))
+
+(define (regtest-statistics-summary-message)
+  (regression-test-group
+   "statistics-summary-message" "string"
+   statistics-summary-message* :none
+   (test "document statistics summary"
+         '("Document" 12 3 2)
+         "Document statistics: 12 characters, 3 words, 2 lines")
+   (test "selection statistics summary"
+         '("Selection" 5 1 1)
+         "Selection statistics: 5 characters, 1 words, 1 lines")))
+
+(tm-define (regtest-tm-tools)
+  (let ((n (+ (regtest-statistics-count-message)
+              (regtest-statistics-summary-message))))
+    (display* "Total: " (object->string n) " tests.\n")
+    (display "Test suite of tm-tools: ok\n")))

--- a/TeXmacs/progs/texmacs/texmacs/tm-tools.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-tools.scm
@@ -42,17 +42,43 @@
       (selection-tree)
       (buffer-tree)))
 
+(tm-define (statistics-scope-name)
+  (if (selection-active-any?) "Selection" "Document"))
+
+(tm-define (statistics-count-message scope kind nr)
+  (string-append scope " " kind " count: " (number->string nr)))
+
+(tm-define (statistics-summary-message scope characters words lines)
+  (string-append scope " statistics: "
+                 (number->string characters) " characters, "
+                 (number->string words) " words, "
+                 (number->string lines) " lines"))
+
+(tm-define (show-statistics-summary)
+  (let* ((doc (selection-or-document))
+         (scope (statistics-scope-name))
+         (characters (count-characters doc))
+         (words (count-words doc))
+         (lines (count-lines doc)))
+    (set-message (statistics-summary-message scope characters words lines) "")))
+
 (tm-define (show-character-count)
-  (with nr (count-characters (selection-or-document))
-    (set-message (string-append "Character count: " (number->string nr)) "")))
+  (let* ((doc (selection-or-document))
+         (scope (statistics-scope-name))
+         (nr (count-characters doc)))
+    (set-message (statistics-count-message scope "character" nr) "")))
 
 (tm-define (show-word-count)
-  (with nr (count-words (selection-or-document))
-    (set-message (string-append "Word count: " (number->string nr)) "")))
+  (let* ((doc (selection-or-document))
+         (scope (statistics-scope-name))
+         (nr (count-words doc)))
+    (set-message (statistics-count-message scope "word" nr) "")))
 
 (tm-define (show-line-count)
-  (with nr (count-lines (selection-or-document))
-    (set-message (string-append "Line count: " (number->string nr)) "")))
+  (let* ((doc (selection-or-document))
+         (scope (statistics-scope-name))
+         (nr (count-lines doc)))
+    (set-message (statistics-count-message scope "line" nr) "")))
 
 (define (save-aux-enabled?) (== (get-env "save-aux") "true"))
 (tm-define (toggle-save-aux)


### PR DESCRIPTION
## Summary
- Add a `Count all` entry under `Tools -> Statistics` that reports characters, words, and lines together.
- Prefix statistics messages with `Document` or `Selection` so the status bar makes the counted scope explicit.
- Add Scheme regression coverage for the new statistics message helpers and include it in `run-all-tests`.

## Validation
- Scheme reader check over the touched Scheme files: `scheme read ok`
- `cmake --build ../../build/texmacs-qt611 --parallel 2`: `Built target TeXmacs`
- `TeXmacs -H -v`: `TeXmacs version 2.1.4`
- `ctest --test-dir ../../build/texmacs-qt611 --output-on-failure`: completed with `No tests were found!!!` because this local Qt6 build has tests disabled.

## Notes
- The local `CMakeLists.txt` build-environment patch was intentionally not included in this PR.